### PR TITLE
Remove removed deprecated documentation

### DIFF
--- a/website/docs/d/pi_dhcps.html.markdown
+++ b/website/docs/d/pi_dhcps.html.markdown
@@ -42,7 +42,6 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested scheme for `servers`:
   - `dhcp_id` - (String) ID of the DHCP Server.
-  - `network` - (String) ID of the DHCP Server private network (deprecated - replaced by `network_id`).
   - `network_id`- (String) ID of the DHCP Server private network.
   - `network_name` - (String) Name of the DHCP Server private network.
   - `status` - (String) Status of the DHCP Server.


### PR DESCRIPTION
The deprecated network field has already been removed in the dhcp data source, but was left in the documentation.