### PR TITLE
Initialize Attr_Fault attribute to nil on first read 

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -560,6 +560,8 @@ func resourceIBMPIInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 	}
 	if powervmdata.Fault != nil {
 		d.Set(Attr_Fault, flattenPvmInstanceFault(powervmdata.Fault))
+	} else {
+		d.Set(Attr_Fault, nil)
 	}
 	return nil
 }


### PR DESCRIPTION
Attr_Fault should be initialized to nil on first read, so that terraform apply doesn't think there's a value left to compute after vm creation.

JIRA: https://jsw.ibm.com/browse/PPC-5127

