### PR TITLE
Add GRS arguments for pi_instance boot volume replication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.5
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20240719075425-078fcb3a55be
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.7.0
+	github.com/IBM-Cloud/power-go-client v1.8.0-beta4
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.5
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20240719075425-078fcb3a55be
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.8.0-beta4
+	github.com/IBM-Cloud/power-go-client v1.8.1
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.3.0
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20240719075425-078fcb3a55be/go.mod h1:/7h
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.7.0 h1:/GuGwPMTKoCZACfnwt7b6wKr4v32q1VO1AMFGNETRN4=
-github.com/IBM-Cloud/power-go-client v1.7.0/go.mod h1:9izycYAmNQ+NAdVPXDC3fHYxqWLjlR2YiwqKYveMv5Y=
+github.com/IBM-Cloud/power-go-client v1.8.0-beta4 h1:mT3UaAo3RIJCsvjDZWQuqjr7CooDmB95VyI1ogKl4IY=
+github.com/IBM-Cloud/power-go-client v1.8.0-beta4/go.mod h1:oAkZiHX25cmr2Yun5V0q6CpnUemegvSrpcEy/oQcjzU=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20240719075425-078fcb3a55be/go.mod h1:/7h
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.8.0-beta4 h1:mT3UaAo3RIJCsvjDZWQuqjr7CooDmB95VyI1ogKl4IY=
-github.com/IBM-Cloud/power-go-client v1.8.0-beta4/go.mod h1:oAkZiHX25cmr2Yun5V0q6CpnUemegvSrpcEy/oQcjzU=
+github.com/IBM-Cloud/power-go-client v1.8.1 h1:tx1aPJmIQrNru1MD1VHGNasGx3eRIs0zzPZ0KvdFQrg=
+github.com/IBM-Cloud/power-go-client v1.8.1/go.mod h1:N4RxrsMUvBQjSQ/qPk0iMZ8zK+fZPRTnHi/gTaASw0g=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -61,6 +61,7 @@ const (
 	Arg_ReplicationEnabled                  = "pi_replication_enabled"
 	Arg_ReplicationPolicy                   = "pi_replication_policy"
 	Arg_ReplicationScheme                   = "pi_replication_scheme"
+	Arg_ReplicationSites                    = "pi_replication_sites"
 	Arg_ResourceGroupID                     = "pi_resource_group_id"
 	Arg_SAP                                 = "sap"
 	Arg_SAPDeploymentType                   = "pi_sap_deployment_type"

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -10,6 +10,7 @@ const (
 	Arg_AffinityVolume                      = "pi_affinity_volume"
 	Arg_AntiAffinityInstances               = "pi_anti_affinity_instances"
 	Arg_AntiAffinityVolumes                 = "pi_anti_affinity_volumes"
+	Arg_BootVolumeReplicationEnabled        = "pi_boot_volume_replication_enabled"
 	Arg_Cidr                                = "pi_cidr"
 	Arg_CloudConnectionID                   = "pi_cloud_connection_id"
 	Arg_CloudConnectionName                 = "pi_cloud_connection_name"

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -251,7 +251,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{Prefix, Suffix}),
 			},
 			Arg_ReplicationSites: {
-				Description: "Indicates the replication site of the boot volume.",
+				Description: "Indicates the replication sites of the boot volume.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1347,18 +1347,6 @@ func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInsta
 	if r, ok := d.GetOk(Arg_ReplicationScheme); ok {
 		replicationNamingScheme = r.(string)
 	}
-	var bootVolumeReplicationEnabled bool
-	if bootVolumeReplicationBoolean, ok := d.GetOk(Arg_BootVolumeReplicationEnabled); ok {
-		bootVolumeReplicationEnabled = bootVolumeReplicationBoolean.(bool)
-	}
-	var replicationSites []string
-	if sites, ok := d.GetOk(Arg_ReplicationSites); ok {
-		if !bootVolumeReplicationEnabled {
-			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
-		} else {
-			replicationSites = flex.ExpandStringList(sites.([]interface{}))
-		}
-	}
 
 	instances := &models.PVMInstanceMultiCreate{
 		AffinityPolicy: &replicationpolicy,
@@ -1367,13 +1355,11 @@ func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInsta
 	}
 
 	body := &models.SAPCreate{
-		BootVolumeReplicationEnabled: &bootVolumeReplicationEnabled,
-		ImageID:                      &imageid,
-		Instances:                    instances,
-		Name:                         &name,
-		Networks:                     pvmNetworks,
-		ProfileID:                    &profileID,
-		ReplicationSites:             replicationSites,
+		ImageID:   &imageid,
+		Instances: instances,
+		Name:      &name,
+		Networks:  pvmNetworks,
+		ProfileID: &profileID,
 	}
 
 	if v, ok := d.GetOk(Arg_SAPDeploymentType); ok {
@@ -1406,6 +1392,20 @@ func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInsta
 
 	if st, ok := d.GetOk(Arg_StorageType); ok {
 		body.StorageType = st.(string)
+	}
+	var bootVolumeReplicationEnabled bool
+	if bootVolumeReplicationBoolean, ok := d.GetOk(Arg_BootVolumeReplicationEnabled); ok {
+		bootVolumeReplicationEnabled = bootVolumeReplicationBoolean.(bool)
+		body.BootVolumeReplicationEnabled = &bootVolumeReplicationEnabled
+	}
+	var replicationSites []string
+	if sites, ok := d.GetOk(Arg_ReplicationSites); ok {
+		if !bootVolumeReplicationEnabled {
+			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
+		} else {
+			replicationSites = flex.ExpandStringList(sites.([]interface{}))
+			body.ReplicationSites = replicationSites
+		}
 	}
 	if sp, ok := d.GetOk(Arg_StoragePool); ok {
 		body.StoragePool = sp.(string)
@@ -1502,21 +1502,6 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 	if r, ok := d.GetOk(Arg_ReplicationScheme); ok {
 		replicationNamingScheme = r.(string)
 	}
-
-	var bootVolumeReplicationEnabled bool
-	if bootVolumeReplicationBoolean, ok := d.GetOk(Arg_BootVolumeReplicationEnabled); ok {
-		bootVolumeReplicationEnabled = bootVolumeReplicationBoolean.(bool)
-	}
-
-	var replicationSites []string
-	if sites, ok := d.GetOk(Arg_ReplicationSites); ok {
-		if !bootVolumeReplicationEnabled {
-			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
-		} else {
-			replicationSites = flex.ExpandStringList(sites.([]interface{}))
-		}
-	}
-
 	var pinpolicy string
 	if p, ok := d.GetOk(Arg_PinPolicy); ok {
 		pinpolicy = p.(string)
@@ -1531,19 +1516,17 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 	}
 
 	body := &models.PVMInstanceCreate{
-		BootVolumeReplicationEnabled: &bootVolumeReplicationEnabled,
-		Processors:                   &procs,
-		Memory:                       &mem,
-		ServerName:                   flex.PtrToString(name),
-		SysType:                      systype,
-		ImageID:                      flex.PtrToString(imageid),
-		ProcType:                     flex.PtrToString(processortype),
-		Replicants:                   replicants,
-		UserData:                     encodeBase64(userData),
-		ReplicantNamingScheme:        flex.PtrToString(replicationNamingScheme),
-		ReplicantAffinityPolicy:      flex.PtrToString(replicationpolicy),
-		ReplicationSites:             replicationSites,
-		Networks:                     pvmNetworks,
+		Processors:              &procs,
+		Memory:                  &mem,
+		ServerName:              flex.PtrToString(name),
+		SysType:                 systype,
+		ImageID:                 flex.PtrToString(imageid),
+		ProcType:                flex.PtrToString(processortype),
+		Replicants:              replicants,
+		UserData:                encodeBase64(userData),
+		ReplicantNamingScheme:   flex.PtrToString(replicationNamingScheme),
+		ReplicantAffinityPolicy: flex.PtrToString(replicationpolicy),
+		Networks:                pvmNetworks,
 	}
 	if s, ok := d.GetOk(Arg_KeyPairName); ok {
 		sshkey := s.(string)
@@ -1656,6 +1639,21 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 	if deploymentTarget, ok := d.GetOk(Arg_DeploymentTarget); ok {
 		body.DeploymentTarget = expandDeploymentTarget(deploymentTarget.(*schema.Set).List())
 	}
+	var bootVolumeReplicationEnabled bool
+	if bootVolumeReplicationBoolean, ok := d.GetOk(Arg_BootVolumeReplicationEnabled); ok {
+		bootVolumeReplicationEnabled = bootVolumeReplicationBoolean.(bool)
+		body.BootVolumeReplicationEnabled = &bootVolumeReplicationEnabled
+	}
+	var replicationSites []string
+	if sites, ok := d.GetOk(Arg_ReplicationSites); ok {
+		if !bootVolumeReplicationEnabled {
+			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
+		} else {
+			replicationSites = flex.ExpandStringList(sites.([]interface{}))
+			body.ReplicationSites = replicationSites
+		}
+	}
+
 	pvmList, err := client.Create(body)
 
 	if err != nil {

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -254,7 +254,6 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Description: "List of replication sites for instance.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,
-				MinItems:    1,
 				Optional:    true,
 				Type:        schema.TypeList,
 			},
@@ -1402,8 +1401,10 @@ func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInsta
 		if !bootVolumeReplicationEnabled {
 			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
 		} else {
-			replicationSites = flex.ExpandStringList(sites.([]interface{}))
-			body.ReplicationSites = replicationSites
+			if len(sites.([]interface{})) > 0 {
+				replicationSites = flex.ExpandStringList(sites.([]interface{}))
+				body.ReplicationSites = replicationSites
+			}
 		}
 	}
 	if sp, ok := d.GetOk(Arg_StoragePool); ok {

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -251,7 +251,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{Prefix, Suffix}),
 			},
 			Arg_ReplicationSites: {
-				Description: "List of replication sites for instance.",
+				Description: "List of replication sites for the boot volume of the instance.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1347,7 +1347,6 @@ func createSAPInstance(d *schema.ResourceData, sapClient *instance.IBMPISAPInsta
 	if r, ok := d.GetOk(Arg_ReplicationScheme); ok {
 		replicationNamingScheme = r.(string)
 	}
-
 	instances := &models.PVMInstanceMultiCreate{
 		AffinityPolicy: &replicationpolicy,
 		Count:          replicants,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -72,7 +72,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Type:          schema.TypeList,
 			},
 			Arg_BootVolumeReplicationEnabled: {
-				Description: "Determines if instance boot volume is replication enabled when created.",
+				Description: "Indicates if the boot volume should be replication enabled or not.",
 				ForceNew:    true,
 				Optional:    true,
 				Type:        schema.TypeBool,
@@ -251,7 +251,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				ValidateFunc: validate.ValidateAllowedStringValues([]string{Prefix, Suffix}),
 			},
 			Arg_ReplicationSites: {
-				Description: "List of replication sites for the boot volume of the instance.",
+				Description: "Indicates the replication site of the boot volume.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				ForceNew:    true,
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1649,8 +1649,10 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 		if !bootVolumeReplicationEnabled {
 			return nil, fmt.Errorf("must set %s to true in order to specify replication sites", Arg_BootVolumeReplicationEnabled)
 		} else {
-			replicationSites = flex.ExpandStringList(sites.([]interface{}))
-			body.ReplicationSites = replicationSites
+			if len(sites.([]interface{})) > 0 {
+				replicationSites = flex.ExpandStringList(sites.([]interface{}))
+				body.ReplicationSites = replicationSites
+			}
 		}
 	}
 

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -829,7 +829,7 @@ func testAccIBMPIInstanceGRSConfig(name string, instanceHealthStatus string, mem
 		pi_boot_volume_replication_enabled = true
 		pi_memory            			   = "%[7]s"
 		pi_processors        			   = "%[6]s"
-		pi_instance_name                   = "%[2]s"
+		pi_instance_name                           = "%[2]s"
 		pi_proc_type          			   = "shared"
 		pi_image_id           			   = data.ibm_pi_image.power_image.id
 		pi_sys_type          			   = "e980"

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -788,7 +788,7 @@ func TestAccIBMPIInstanceDeploymentTypeNoStorage(t *testing.T) {
 
 func TestAccIBMPIInstanceDeploymentGRS(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
-	bootVolumeData := "data.ibm_pi_volume.power_boot_volume"
+	bootVolumeData := "data.ibm_pi_volume.power_boot_volume_data"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
@@ -817,11 +817,11 @@ func testAccIBMPIInstanceGRSConfig(name string, instanceHealthStatus string, mem
 		pi_cloud_instance_id = "%[1]s"
 		pi_network_name      = "%[4]s"
 	}  
-	data "ibm_pi_volume" "power_boot_volume" {
+	data "ibm_pi_volume" "power_boot_volume_data" {
 		pi_cloud_instance_id = "%[1]s"
-		pi_volume_name 		 = data.ibm_pi_instance.power_instance_data.volumes[0]
+		pi_volume_name       = data.ibm_pi_instance_volumes.power_instance_volumes_data.instance_volumes[0].name
 	}
-	data "ibm_pi_instance" "power_instance_data" {
+	data "ibm_pi_instance_volumes" "power_instance_volumes_data" {
 		pi_cloud_instance_id = "%[1]s"
 		pi_instance_name     = ibm_pi_instance.power_instance.pi_instance_name
 	}

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -785,3 +785,61 @@ func TestAccIBMPIInstanceDeploymentTypeNoStorage(t *testing.T) {
 		},
 	})
 }
+
+func TestAccIBMPIInstanceDeploymentGRS(t *testing.T) {
+	instanceRes := "ibm_pi_instance.power_instance"
+	bootVolumeData := "data.ibm_pi_volume.power_boot_volume"
+	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { acc.TestAccPreCheck(t) },
+		Providers:    acc.TestAccProviders,
+		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccIBMPIInstanceGRSConfig(name, helpers.PIInstanceHealthOk, "2", "0.25"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIBMPIInstanceExists(instanceRes),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttr(bootVolumeData, "replication_enabled", "true"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIBMPIInstanceGRSConfig(name string, instanceHealthStatus string, memory string, proc string) string {
+	return fmt.Sprintf(`
+	data "ibm_pi_image" "power_image" {
+		pi_image_name        = "%[3]s"
+		pi_cloud_instance_id = "%[1]s"
+	}
+	data "ibm_pi_network" "power_networks" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_network_name      = "%[4]s"
+	}  
+	data "ibm_pi_volume" "power_boot_volume" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_volume_name 		 = data.ibm_pi_instance.power_instance_data.volumes[0]
+	}
+	data "ibm_pi_instance" "power_instance_data" {
+		pi_cloud_instance_id = "%[1]s"
+		pi_instance_name     = ibm_pi_instance.power_instance.pi_instance_name
+	}
+	resource "ibm_pi_instance" "power_instance" {
+		pi_boot_volume_replication_enabled = true
+		pi_memory            			   = "%[7]s"
+		pi_processors        			   = "%[6]s"
+		pi_instance_name                   = "%[2]s"
+		pi_proc_type          			   = "shared"
+		pi_image_id           			   = data.ibm_pi_image.power_image.id
+		pi_sys_type          			   = "e980"
+		pi_cloud_instance_id  			   = "%[1]s"
+		pi_storage_pool       			   = data.ibm_pi_image.power_image.storage_pool		
+		pi_pin_policy        			   = "none"
+		pi_health_status      			   = "%[5]s"
+		pi_network {
+			network_id = data.ibm_pi_network.power_networks.id
+		}
+	}
+	`, acc.Pi_cloud_instance_id, name, acc.Pi_image, acc.Pi_network_name, instanceHealthStatus, proc, memory)
+}

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -796,7 +796,7 @@ func TestAccIBMPIInstanceDeploymentGRS(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccIBMPIInstanceGRSConfig(name, helpers.PIInstanceHealthOk, "2", "0.25"),
+				Config: testAccIBMPIInstanceGRSConfig(name, power.OK, "2", "0.25"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -67,7 +67,7 @@ Review the argument references that you can specify for your resource.
 - `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
 - `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
-- `pi_boot_volume_replication_enabled` - (Optional, Boolean) Specifies whether the boot volume of the created VSI will be replication enabled. Destroys and creates new instance if changed.
+- `pi_boot_volume_replication_enabled` - (Optional, Boolean) Determines if instance boot volume is replication enabled when created.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_deployment_target` - (Optional, List) The deployment of a dedicated host. Max items: 1.
   

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -67,7 +67,7 @@ Review the argument references that you can specify for your resource.
 - `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
 - `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
-- `pi_boot_volume_replication_enabled` - (Optional, Boolean) Determines if instance boot volume is replication enabled when created.
+- `pi_boot_volume_replication_enabled` - (Optional, Boolean) Indicates if the boot volume should be replication enabled or not.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_deployment_target` - (Optional, List) The deployment of a dedicated host. Max items: 1.
   
@@ -107,7 +107,7 @@ Review the argument references that you can specify for your resource.
 - `pi_replicants` - (Optional, Integer) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
 - `pi_replication_policy` - (Optional, String) The replication policy that you want to use, either `affinity`, `anti-affinity` or `none`. If this parameter is not set, `none` is used by default.
 - `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
-- `pi_replication_sites` - (Optional, List) List of replication sites for the boot volume of the instance.
+- `pi_replication_sites` - (Optional, List) Indicates the replication site of the boot volume.
 - `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
   - Required only when creating SAP instances.
 - `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -107,7 +107,7 @@ Review the argument references that you can specify for your resource.
 - `pi_replicants` - (Optional, Integer) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
 - `pi_replication_policy` - (Optional, String) The replication policy that you want to use, either `affinity`, `anti-affinity` or `none`. If this parameter is not set, `none` is used by default.
 - `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
-- `pi_replication_sites` - (Optional, List) Indicates the replication site of the boot volume.
+- `pi_replication_sites` - (Optional, List) Indicates the replication sites of the boot volume.
 - `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
   - Required only when creating SAP instances.
 - `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -106,6 +106,7 @@ Review the argument references that you can specify for your resource.
 - `pi_replicants` - (Optional, Integer) The number of instances that you want to provision with the same configuration. If this parameter is not set,  `1` is used by default.
 - `pi_replication_policy` - (Optional, String) The replication policy that you want to use, either `affinity`, `anti-affinity` or `none`. If this parameter is not set, `none` is used by default.
 - `pi_replication_scheme` - (Optional, String) The replication scheme that you want to set, either `prefix` or `suffix`.
+- `pi_replication_sites` - (Optional, List) List of replication sites for the boot volume of the instance.
 - `pi_sap_profile_id` - (Optional, String) SAP Profile ID for the amount of cores and memory.
   - Required only when creating SAP instances.
 - `pi_sap_deployment_type` - (Optional, String) Custom SAP deployment type information (For Internal Use Only).

--- a/website/docs/r/pi_instance.html.markdown
+++ b/website/docs/r/pi_instance.html.markdown
@@ -67,6 +67,7 @@ Review the argument references that you can specify for your resource.
 - `pi_affinity_volume`- (Optional, String) Volume (ID or Name) to base storage affinity policy against; required if requesting `affinity` and `pi_affinity_instance` is not provided.
 - `pi_anti_affinity_instances` - (Optional, String) List of pvmInstances to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_volumes` is not provided.
 - `pi_anti_affinity_volumes`- (Optional, String) List of volumes to base storage anti-affinity policy against; required if requesting `anti-affinity` and `pi_anti_affinity_instances` is not provided.
+- `pi_boot_volume_replication_enabled` - (Optional, Boolean) Specifies whether the boot volume of the created VSI will be replication enabled. Destroys and creates new instance if changed.
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_deployment_target` - (Optional, List) The deployment of a dedicated host. Max items: 1.
   


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
=== RUN   TestAccIBMPIInstanceDeploymentGRS
--- PASS: TestAccIBMPIInstanceDeploymentGRS (1164.25s)
PASS
```

Description:
- Added argument pi_boot_volume_replication_enabled (Boolean) which specifies whether the boot volume will be replication enabled
- Added argument pi_replication_sites (List) which specifies replication sites for boot volume replication. Argument above must be true to use this.
- Add GRS test to see if created boot volume replication and site is set correctly