### PR TITLE
Fix Null Pointer bug in capture tag creation

### DIFF
--- a/ibm/service/power/resource_ibm_pi_capture.go
+++ b/ibm/service/power/resource_ibm_pi_capture.go
@@ -198,11 +198,13 @@ func resourceIBMPICaptureCreate(ctx context.Context, d *schema.ResourceData, met
 		if err != nil {
 			log.Printf("Error on get of ibm pi capture (%s) while applying pi_user_tags: %s", capturename, err)
 		}
-		if imagedata.Crn != "" {
-			oldList, newList := d.GetChange(Arg_UserTags)
-			err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, string(imagedata.Crn), "", UserTagType)
-			if err != nil {
-				log.Printf("Error on update of pi capture (%s) pi_user_tags during creation: %s", *imagedata.ImageID, err)
+		if imagedata != nil {
+			if imagedata.Crn != "" {
+				oldList, newList := d.GetChange(Arg_UserTags)
+				err = flex.UpdateGlobalTagsUsingCRN(oldList, newList, meta, string(imagedata.Crn), "", UserTagType)
+				if err != nil {
+					log.Printf("Error on update of pi capture (%s) pi_user_tags during creation: %s", *imagedata.ImageID, err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Description:
Fixes bug where capture image data CRN was read even though it could be nil during user tag handling in the creation function, which would cause an error.

Output from acceptance testing:

```
=== RUN   TestAccIBMPICaptureBasic
--- PASS: TestAccIBMPICaptureBasic (81.80s)
PASS
```

```
=== RUN   TestAccIBMPICaptureUserTags
--- PASS: TestAccIBMPICaptureUserTags (124.27s)
PASS
```
