### PR TITLE
Custom Diff User Tags

### DIFF
--- a/ibm/flex/structures.go
+++ b/ibm/flex/structures.go
@@ -2902,7 +2902,25 @@ func ResourceTagsCustomizeDiff(diff *schema.ResourceDiff) error {
 	}
 	return nil
 }
+func ResourcePowerUserTagsCustomizeDiff(diff *schema.ResourceDiff) error {
 
+	if diff.Id() != "" && diff.HasChange("pi_user_tags") {
+		// power tags
+		o, n := diff.GetChange("pi_user_tags")
+		oldSet := o.(*schema.Set)
+		newSet := n.(*schema.Set)
+		removeInt := oldSet.Difference(newSet).List()
+		addInt := newSet.Difference(oldSet).List()
+		if v := os.Getenv("IC_ENV_TAGS"); v != "" {
+			s := strings.Split(v, ",")
+			if len(removeInt) == len(s) && len(addInt) == 0 {
+				fmt.Println("Suppresing the TAG diff ")
+				return diff.Clear("pi_user_tags")
+			}
+		}
+	}
+	return nil
+}
 func OnlyInUpdateDiff(resources []string, diff *schema.ResourceDiff) error {
 	for _, r := range resources {
 		if diff.HasChange(r) && diff.Id() == "" {

--- a/ibm/service/power/resource_ibm_pi_capture.go
+++ b/ibm/service/power/resource_ibm_pi_capture.go
@@ -19,6 +19,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -38,6 +39,11 @@ func ResourceIBMPICapture() *schema.Resource {
 			Delete: schema.DefaultTimeout(50 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 
@@ -108,6 +114,7 @@ func ResourceIBMPICapture() *schema.Resource {
 				Description: "Cloud Storage Image Path (bucket-name [/folder/../..])",
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "List of user tags attached to the resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -37,6 +38,11 @@ func ResourceIBMPIImage() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			helpers.PICloudInstanceId: {
@@ -191,6 +197,7 @@ func ResourceIBMPIImage() *schema.Resource {
 				},
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -36,6 +37,11 @@ func ResourceIBMPIInstance() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -315,6 +321,7 @@ func ResourceIBMPIInstance() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/apparentlymart/go-cidr/cidr"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -43,6 +44,11 @@ func ResourceIBMPINetwork() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			helpers.PINetworkType: {
@@ -123,6 +129,7 @@ func ResourceIBMPINetwork() *schema.Resource {
 				},
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_network_address_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group.go
@@ -35,7 +35,7 @@ func ResourceIBMPINetworkAddressGroup() *schema.Resource {
 		},
 		CustomizeDiff: customdiff.Sequence(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
 			},
 		),
 		Schema: map[string]*schema.Schema{
@@ -54,6 +54,7 @@ func ResourceIBMPINetworkAddressGroup() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags associated with this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,6 +36,11 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -69,6 +75,7 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_network_port_attach.go
+++ b/ibm/service/power/resource_ibm_pi_network_port_attach.go
@@ -32,6 +32,7 @@ func ResourceIBMPINetworkPortAttach() *schema.Resource {
 			Create: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
+
 		Schema: map[string]*schema.Schema{
 			helpers.PICloudInstanceId: {
 				Type:     schema.TypeString,

--- a/ibm/service/power/resource_ibm_pi_network_security_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group.go
@@ -36,7 +36,7 @@ func ResourceIBMPINetworkSecurityGroup() *schema.Resource {
 		},
 		CustomizeDiff: customdiff.Sequence(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
-				return flex.ResourceTagsCustomizeDiff(diff)
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
 			},
 		),
 		Schema: map[string]*schema.Schema{
@@ -55,6 +55,7 @@ func ResourceIBMPINetworkSecurityGroup() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags associated with this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_network_security_group_member.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_member.go
@@ -301,7 +301,7 @@ func resourceIBMPINetworkSecurityGroupMemberRead(ctx context.Context, d *schema.
 		if err != nil {
 			log.Printf("Error on get of network security group (%s) user_tags: %s", parts[1], err)
 		}
-		d.Set(Arg_UserTags, userTags)
+		d.Set(Attr_UserTags, userTags)
 	}
 	if len(networkSecurityGroup.Members) > 0 {
 		members := []map[string]interface{}{}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
@@ -421,7 +421,7 @@ func resourceIBMPINetworkSecurityGroupRuleRead(ctx context.Context, d *schema.Re
 		if err != nil {
 			log.Printf("Error on get of network security group (%s) user_tags: %s", nsgID, err)
 		}
-		d.Set(Arg_UserTags, userTags)
+		d.Set(Attr_UserTags, userTags)
 	}
 
 	if len(networkSecurityGroup.Members) > 0 {

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -16,6 +16,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -33,6 +34,11 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -78,6 +84,7 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 				Type:        schema.TypeInt,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_snapshot.go
@@ -14,6 +14,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -32,6 +33,11 @@ func ResourceIBMPISnapshot() *schema.Resource {
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -59,6 +65,7 @@ func ResourceIBMPISnapshot() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_volume.go
+++ b/ibm/service/power/resource_ibm_pi_volume.go
@@ -17,6 +17,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -35,6 +36,11 @@ func ResourceIBMPIVolume() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -96,6 +102,7 @@ func ResourceIBMPIVolume() *schema.Resource {
 				Type:        schema.TypeSet,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "The user tags attached to this resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,

--- a/ibm/service/power/resource_ibm_pi_workspace.go
+++ b/ibm/service/power/resource_ibm_pi_workspace.go
@@ -11,6 +11,7 @@ import (
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/validate"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -29,6 +30,11 @@ func ResourceIBMPIWorkspace() *schema.Resource {
 			Delete: schema.DefaultTimeout(30 * time.Minute),
 			Update: schema.DefaultTimeout(10 * time.Minute),
 		},
+		CustomizeDiff: customdiff.Sequence(
+			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
+				return flex.ResourcePowerUserTagsCustomizeDiff(diff)
+			},
+		),
 
 		Schema: map[string]*schema.Schema{
 			// Arguments
@@ -62,6 +68,7 @@ func ResourceIBMPIWorkspace() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_UserTags: {
+				Computed:    true,
 				Description: "List of user tags attached to the resource.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
 				Optional:    true,


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
=== RUN   TestAccIBMPICaptureUserTags
--- PASS: TestAccIBMPICaptureUserTags (204.92s)
PASS

=== RUN   TestAccIBMPIImageUserTags
--- PASS: TestAccIBMPIImageUserTags (123.24s)
PASS

=== RUN   TestAccIBMPIInstanceUserTags
--- PASS: TestAccIBMPIInstanceUserTags (956.58s)
PASS

=== RUN   TestAccIBMPINetworkUserTags
--- PASS: TestAccIBMPINetworkUserTags (76.79s)
PASS

=== RUN   TestAccIBMPINetworkAddressGroupBasic
--- PASS: TestAccIBMPINetworkAddressGroupBasic (34.86s)
PASS

=== RUN   TestAccIBMPINetworkInterfaceBasic
--- PASS: TestAccIBMPINetworkInterfaceBasic (31.60s)
PASS

=== RUN   TestAccIBMPISPPUserTags
--- PASS: TestAccIBMPISPPUserTags (204.37s)
PASS

=== RUN   TestAccIBMPIInstanceSnapshotUserTags
--- PASS: TestAccIBMPIInstanceSnapshotUserTags (930.61s)
PASS

=== RUN   TestAccIBMPIVolumeUserTags
--- PASS: TestAccIBMPIVolumeUserTags (92.77s)
PASS

=== RUN   TestAccIBMPIWorkspaceUserTags
--- PASS: TestAccIBMPIWorkspaceUserTags (183.66s)
PASS
...
```
