### PR TITLE
Fix shutdown pi_instance name change behavior and refactor refresh functions

### DIFF
--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -463,6 +463,7 @@ const (
 	DeploymentTypeEpic        = "EPIC"
 	DeploymentTypeVMNoStorage = "VMNoStorage"
 	DestinationUnreach        = "destination-unreach"
+	Detach                    = "detach"
 	DHCPVlan                  = "dhcp-vlan"
 	Disable                   = "disable"
 	Echo                      = "echo"

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -448,6 +448,7 @@ const (
 
 	// Allowed Values
 	Affinity                  = "affinity"
+	Any                       = "any"
 	All                       = "all"
 	Allow                     = "allow"
 	AntiAffinity              = "anti-affinity"

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -989,7 +989,7 @@ func isWaitForPIInstanceDeleted(ctx context.Context, client *instance.IBMPIInsta
 	log.Printf("Waiting for  (%s) to be deleted.", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{State_Pending, State_Retry, State_Deleting},
+		Pending:    []string{State_Active, State_Deleting, State_Pending, State_Retry, State_Shutoff},
 		Target:     []string{State_NotFound},
 		Refresh:    isPIInstanceRefreshFunc(client, id, Any),
 		Delay:      Timeout_Delay,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1024,7 +1024,7 @@ func isPIInstanceRefreshFunc(client *instance.IBMPIInstanceClient, id, instanceR
 	return func() (interface{}, string, error) {
 
 		pvm, err := client.Get(id)
-		if err != nil && !strings.Contains(err.Error(), "Not Found") {
+		if err != nil && strings.Contains(err.Error(), NotFound) {
 			return pvm, State_NotFound, nil
 		}
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -989,8 +989,8 @@ func isWaitForPIInstanceDeleted(ctx context.Context, client *instance.IBMPIInsta
 	log.Printf("Waiting for  (%s) to be deleted.", id)
 
 	stateConf := &retry.StateChangeConf{
-		Pending:    []string{State_Active, State_Deleting, State_Pending, State_Retry, State_Shutoff},
-		Target:     []string{State_Deleted, State_NotFound},
+		Pending:    []string{State_Active, State_Deleted, State_Deleting, State_Pending, State_Retry, State_Shutoff},
+		Target:     []string{State_NotFound},
 		Refresh:    isPIInstanceRefreshFunc(client, id, Any),
 		Delay:      Timeout_Delay,
 		MinTimeout: Timeout_Active,
@@ -1025,6 +1025,7 @@ func isPIInstanceRefreshFunc(client *instance.IBMPIInstanceClient, id, instanceR
 
 		pvm, err := client.Get(id)
 		if err != nil && strings.Contains(err.Error(), NotFound) {
+			log.Printf("The power vm does not exist")
 			return pvm, State_NotFound, nil
 		}
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -990,7 +990,7 @@ func isWaitForPIInstanceDeleted(ctx context.Context, client *instance.IBMPIInsta
 
 	stateConf := &retry.StateChangeConf{
 		Pending:    []string{State_Active, State_Deleting, State_Pending, State_Retry, State_Shutoff},
-		Target:     []string{State_NotFound},
+		Target:     []string{State_Deleted, State_NotFound},
 		Refresh:    isPIInstanceRefreshFunc(client, id, Any),
 		Delay:      Timeout_Delay,
 		MinTimeout: Timeout_Active,

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -788,16 +788,9 @@ func resourceIBMPIInstanceUpdate(ctx context.Context, d *schema.ResourceData, me
 			if err != nil {
 				return diag.Errorf("failed to update the lpar with the change %v", err)
 			}
-			if strings.ToLower(instanceState) == State_Shutoff {
-				_, err = isWaitForPIInstanceUpdate(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
-				if err != nil {
-					return diag.FromErr(err)
-				}
-			} else {
-				_, err = isWaitForPIInstanceAvailable(ctx, client, instanceID, Arg_HealthStatus, d.Timeout(schema.TimeoutUpdate))
-				if err != nil {
-					return diag.FromErr(err)
-				}
+			_, err = isWaitForPIInstanceUpdate(ctx, client, instanceID, d.Timeout(schema.TimeoutUpdate))
+			if err != nil {
+				return diag.FromErr(err)
 			}
 		}
 	}

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -394,7 +394,7 @@ func TestAccIBMPIInstanceBasic(t *testing.T) {
 		CheckDestroy: testAccCheckIBMPIInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIInstanceConfig(name, power.Warning),
+				Config: testAccCheckIBMPIInstanceConfig(name, power.OK),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceExists(instanceRes),
 					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
@@ -683,6 +683,7 @@ func testAccIBMPIInstanceMixedStorage(name, healthStatus string) string {
 func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
+	nameUpdated := name + "-updated"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -697,13 +698,12 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, power.OK, "0.5", "4"),
+				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(nameUpdated, power.OK, "0.5", "4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Active)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
-					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", nameUpdated),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -712,6 +712,7 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
+	nameUpdated := name + "-updated"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -725,13 +726,12 @@ func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, power.OK, "0.5", "4", "stop"),
+				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(nameUpdated, power.OK, "0.5", "4", "stop"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Shutoff)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
-					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", nameUpdated),
 				),
-				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -683,7 +683,6 @@ func testAccIBMPIInstanceMixedStorage(name, healthStatus string) string {
 func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
-	nameUpdated := name + "-updated"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -698,11 +697,11 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(nameUpdated, power.OK, "0.5", "4"),
+				Config: testAccCheckIBMPIActiveInstanceConfigUpdate(name, power.OK, "0.5", "4"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Active)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
-					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", nameUpdated),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
 			},
 		},
@@ -712,7 +711,6 @@ func TestAccIBMPIInstanceUpdateActiveState(t *testing.T) {
 func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 	instanceRes := "ibm_pi_instance.power_instance"
 	name := fmt.Sprintf("tf-pi-instance-%d", acctest.RandIntRange(10, 100))
-	nameUpdated := name + "-updated"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { acc.TestAccPreCheck(t) },
 		Providers:    acc.TestAccProviders,
@@ -726,11 +724,11 @@ func TestAccIBMPIInstanceUpdateStoppedState(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(nameUpdated, power.OK, "0.5", "4", "stop"),
+				Config: testAccCheckIBMPIStoppedInstanceConfigUpdate(name, power.OK, "0.5", "4", "stop"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIBMPIInstanceStatus(instanceRes, strings.ToUpper(power.State_Shutoff)),
 					testAccCheckIBMPIInstanceExists(instanceRes),
-					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", nameUpdated),
+					resource.TestCheckResourceAttr(instanceRes, "pi_instance_name", name),
 				),
 			},
 		},

--- a/ibm/service/power/resource_ibm_pi_instance_test.go
+++ b/ibm/service/power/resource_ibm_pi_instance_test.go
@@ -83,7 +83,7 @@ func testAccCheckIBMPIInstanceDeploymentTypeConfig(name, instanceHealthStatus, e
 	  }
 	  resource "ibm_pi_instance" "power_instance" {
 		pi_cloud_instance_id  = "%[1]s"
-		pi_deployment_type          = "%[6]s"
+		pi_deployment_type    = "%[6]s"
 		pi_health_status      = "%[5]s"
 		pi_image_id           = data.ibm_pi_image.power_image.id
 		pi_instance_name      = "%[2]s"


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:


pi_instance (r)
```
=== RUN   TestAccIBMPIInstanceDeploymentGRS
--- PASS: TestAccIBMPIInstanceDeploymentGRS (910.37s)
PASS

=== RUN   TestAccIBMPIInstanceUserTags
--- PASS: TestAccIBMPIInstanceUserTags (980.91s)
PASS

=== RUN   TestAccIBMPIInstanceBasic
--- PASS: TestAccIBMPIInstanceBasic (667.58s)
PASS

=== RUN   TestAccIBMPIInstanceDeploymentType
--- PASS: TestAccIBMPIInstanceDeploymentType (1177.23s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateActiveState
--- PASS: TestAccIBMPIInstanceUpdateActiveState (1458.95s)
PASS

=== RUN   TestAccIBMPIInstanceUpdateStoppedState
--- PASS: TestAccIBMPIInstanceUpdateStoppedState (1486.56s)
PASS

=== RUN   TestAccIBMPIInstanceNetwork
--- PASS: TestAccIBMPIInstanceNetwork (1062.86s)
PASS

=== RUN   TestAccIBMPISAPInstance
--- PASS: TestAccIBMPISAPInstance (1412.23s)
PASS

=== RUN   TestAccIBMPIInstanceDeploymentTypeNoStorage
--- PASS: TestAccIBMPIInstanceDeploymentTypeNoStorage (505.96s)
PASS
```



### NOTE
Do not merge until tested with VSN items, as it, uses some of these functions.

Also fixes bug when updating virtual optical device
