### PR TITLE
Add sap deployment target check

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -106,9 +106,10 @@ func ResourceIBMPIInstance() *schema.Resource {
 						},
 					},
 				},
-				Optional: true,
-				MaxItems: 1,
-				Type:     schema.TypeSet,
+				MaxItems:     1,
+				Optional:     true,
+				RequiredWith: []string{Arg_SysType},
+				Type:         schema.TypeSet,
 			},
 			Arg_DeploymentType: {
 				Description:  "Custom Deployment Type Information",
@@ -1721,6 +1722,7 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 
 	return pvmList, nil
 }
+
 func expandDeploymentTarget(dt []interface{}) *models.DeploymentTarget {
 	dtexpanded := &models.DeploymentTarget{}
 	for _, v := range dt {
@@ -1730,6 +1732,7 @@ func expandDeploymentTarget(dt []interface{}) *models.DeploymentTarget {
 	}
 	return dtexpanded
 }
+
 func splitID(id string) (id1, id2 string, err error) {
 	parts, err := flex.IdParts(id)
 	if err != nil {


### PR DESCRIPTION
Require system-type to be set if deployment-target is set.

JIRA: https://jsw.ibm.com/browse/POWERIAAS-17001


EDIT:
```
2024-12-17T04:41:58.030-0600 [ERROR] vertex "ibm_pi_instance.example" error: Missing required argument
╷
│ Error: Missing required argument
│ 
│   with ibm_pi_instance.example,
│   on main.tf line 77, in resource "ibm_pi_instance" "example":
│   77: resource "ibm_pi_instance" "example" {
│ 
│ "pi_deployment_target": all of `pi_deployment_target,pi_sys_type` must be specified
╵
2024-12-17T04:41:58.033-0600 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
```