### PR TITLE
[Datasource][Resource] Add dedicated host id attribute to shared processor pool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20241117121028-a3be206688b3
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.9.0
+	github.com/IBM-Cloud/power-go-client v1.10.0
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.4.4
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20241117121028-a3be206688b3/go.mod h1:/7h
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.9.0 h1:nnErpb/7TJQe8P7OfIlJPhSJVq5oyuCJlMje9Ry6XEY=
-github.com/IBM-Cloud/power-go-client v1.9.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
+github.com/IBM-Cloud/power-go-client v1.10.0 h1:yBUHWwvNBmLkWpbZJQJEXoxBa1Dm+eJgMSbk9ljmXUU=
+github.com/IBM-Cloud/power-go-client v1.10.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
@@ -49,6 +49,11 @@ func DataSourceIBMPISharedProcessorPool() *schema.Resource {
 				Description: "The CRN of this resource.",
 				Type:        schema.TypeString,
 			},
+			Attr_DedicatedHostID: {
+				Computed:    true,
+				Description: "The dedicated host ID where the shared processor pool resides.",
+				Type:        schema.TypeString,
+			},
 			Attr_HostID: {
 				Computed:    true,
 				Description: "The host ID where the shared processor pool resides.",
@@ -171,6 +176,7 @@ func dataSourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resou
 			d.Set(Attr_UserTags, tags)
 		}
 	}
+	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Name, response.SharedProcessorPool.Name)
 	d.Set(Attr_ReservedCores, response.SharedProcessorPool.ReservedCores)

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -49,6 +49,11 @@ func DataSourceIBMPISharedProcessorPools() *schema.Resource {
 							Description: "The CRN of this resource.",
 							Type:        schema.TypeString,
 						},
+						Attr_DedicatedHostID: {
+							Computed:    true,
+							Description: "The dedicated host ID where the shared processor pool resides.",
+							Type:        schema.TypeString,
+						},
 						Attr_HostID: {
 							Computed:    true,
 							Description: "The host ID where the shared processor pool resides.",
@@ -113,6 +118,7 @@ func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.Reso
 		key := map[string]interface{}{
 			Attr_AllocatedCores:        *pool.AllocatedCores,
 			Attr_AvailableCores:        *pool.AvailableCores,
+			Attr_DedicatedHostID:       pool.DedicatedHostID,
 			Attr_HostID:                pool.HostID,
 			Attr_Name:                  *pool.Name,
 			Attr_ReservedCores:         *pool.ReservedCores,

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -216,6 +216,7 @@ const (
 	Attr_DatacenterStatus                            = "pi_datacenter_status"
 	Attr_DatacenterType                              = "pi_datacenter_type"
 	Attr_Dedicated                                   = "dedicated"
+	Attr_DedicatedHostID                             = "dedicated_host_id"
 	Attr_Default                                     = "default"
 	Attr_DeleteOnTermination                         = "delete_on_termination"
 	Attr_DeploymentType                              = "deployment_type"

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1727,7 +1727,7 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 		SysType:                 systype,
 		ImageID:                 flex.PtrToString(imageid),
 		ProcType:                flex.PtrToString(processortype),
-		Replicants:              replicants,
+		Replicants:              &replicants,
 		UserData:                encodeBase64(userData),
 		ReplicantNamingScheme:   flex.PtrToString(replicationNamingScheme),
 		ReplicantAffinityPolicy: flex.PtrToString(replicationpolicy),

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -108,6 +108,11 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 				Description: "The CRN of this resource.",
 				Type:        schema.TypeString,
 			},
+			Attr_DedicatedHostID: {
+				Computed:    true,
+				Description: "The dedicated host ID where the shared processor pool resides.",
+				Type:        schema.TypeString,
+			},
 			Attr_HostID: {
 				Computed:    true,
 				Description: "The host ID where the shared processor pool resides.",
@@ -333,6 +338,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 			d.Set(Arg_SharedProcessorPoolPlacementGroups, pgIDs)
 		}
 	}
+	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Status, response.SharedProcessorPool.Status)
 	d.Set(Attr_StatusDetail, response.SharedProcessorPool.StatusDetail)

--- a/website/docs/d/pi_shared_processor_pool.html.markdown
+++ b/website/docs/d/pi_shared_processor_pool.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_shared_processor_pool
+
 Retrieve information about a shared processor pool. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ## Example Usage
+
 ```terraform
 data "ibm_pi_shared_processor_pool" "ds_pool" {
   pi_shared_processor_pool_id   = "my-spp"
@@ -17,32 +19,37 @@ data "ibm_pi_shared_processor_pool" "ds_pool" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
   
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
       zone      =   "lon04"
     }
-  ``` 
+  ```
 
 ## Argument reference
-Review the argument references that you can specify for your data source. 
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 - `pi_shared_processor_pool_id` - (Required, String) The ID of the shared processor pool.
 
 ## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
 - `available_cores` - (Integer) The available cores in the shared processor pool.
 - `crn` - (String) The CRN of this resource.
+- `dedicated_host_id` - (String) The dedicated host ID where the shared processor pool resides.
 - `host_id` - (Integer) The host ID where the shared processor pool resides.
 - `id` - (String) The shared processor pool's unique ID.
 - `instances` - (List) List of server instances deployed in the shared processor pool.

--- a/website/docs/d/pi_shared_processor_pools.html.markdown
+++ b/website/docs/d/pi_shared_processor_pools.html.markdown
@@ -7,22 +7,26 @@ description: |-
 ---
 
 # ibm_pi_shared_processor_pools
+
 Retrieve information about all shared processor pools. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ## Example usage
+
 ```terraform
 data "ibm_pi_shared_processor_pools" "example" {
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,11 +35,13 @@ Example usage:
   ```
   
 ## Argument reference
+
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
 
 ## Attribute reference
+
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `shared_processor_pools` - (List) List of all the shared processor pools.
@@ -44,6 +50,7 @@ In addition to all argument reference list, you can access the following attribu
   - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
   - `available_cores` - (Integer) The available cores in the shared processor pool.
   - `crn` - (String) The CRN of this resource.
+  - `dedicated_host_id` - (String) The dedicated host ID where the shared processor pool resides.
   - `host_id` - (Integer) The host ID where the shared processor pool resides.
   - `name` - (String) The name of the shared processor pool.
   - `reserved_cores` - (Integer) The amount of reserved cores for the shared processor pool.

--- a/website/docs/r/pi_shared_processor_pool.html.markdown
+++ b/website/docs/r/pi_shared_processor_pool.html.markdown
@@ -67,6 +67,7 @@ In addition to all argument reference list, you can access the following attribu
 - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
 - `available_cores` - (Integer) The available cores in the shared processor pool.
 - `crn` - (String) The CRN of this resource.
+- `dedicated_host_id` - (String) The dedicated host ID where the shared processor pool resides.
 - `host_id` - (Integer) The host ID where the shared processor pool resides.
 - `instances` - (List of Map) The list of server instances that are deployed in the shared processor pool.
   


### PR DESCRIPTION
Output from acceptance testing:

data source ibm_pi_shared_processor_pool
```
--- PASS: TestAccIBMPIPISharedProcessorPoolDataSource_basic (26.10s)
PASS
```

data source ibm_pi_shared_processor_pools
```
--- PASS: TestAccIBMPISharedProcessorPoolsDataSourceBasic (15.85s)
PASS
```

resource ibm_pi_shared_processor_pool
```
--- PASS: TestAccIBMPISPPbasic (49.09s)
PASS

--- PASS: TestAccIBMPISPPUserTags (68.63s)
PASS
```