### PR TITLE
[Datasource][Resource] Add network security group ids field to network interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20241117121028-a3be206688b3
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.9.0
+	github.com/IBM-Cloud/power-go-client v1.10.0
 	github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca
 	github.com/IBM/appconfiguration-go-admin-sdk v0.4.4
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20241117121028-a3be206688b3/go.mod h1:/7h
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
 github.com/IBM-Cloud/ibm-cloud-cli-sdk v0.5.3/go.mod h1:RiUvKuHKTBmBApDMUQzBL14pQUGKcx/IioKQPIcRQjs=
-github.com/IBM-Cloud/power-go-client v1.9.0 h1:nnErpb/7TJQe8P7OfIlJPhSJVq5oyuCJlMje9Ry6XEY=
-github.com/IBM-Cloud/power-go-client v1.9.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
+github.com/IBM-Cloud/power-go-client v1.10.0 h1:yBUHWwvNBmLkWpbZJQJEXoxBa1Dm+eJgMSbk9ljmXUU=
+github.com/IBM-Cloud/power-go-client v1.10.0/go.mod h1:UDyXeIKEp6r7yWUXYu3r0ZnFSlNZ2YeQTHwM2Tmlgv0=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/apigateway-go-sdk v0.0.0-20210714141226-a5d5d49caaca h1:crniVcf+YcmgF03NmmfonXwSQ73oJF+IohFYBwknMxs=

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -103,7 +103,7 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 			},
 			Attr_Status: {
 				Computed:    true,
-				Description: "The status of the network address group.",
+				Description: "The status of the network interface.",
 				Type:        schema.TypeString,
 			},
 			Attr_UserTags: {

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -8,14 +8,13 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/power-go-client/power/models"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func DataSourceIBMPINetworkInterface() *schema.Resource {
@@ -39,7 +38,7 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_NetworkInterfaceID: {
-				Description:  "Network Interface ID.",
+				Description:  "Network interface ID.",
 				ForceNew:     true,
 				Required:     true,
 				Type:         schema.TypeString,
@@ -48,12 +47,12 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 			// Attributes
 			Attr_CRN: {
 				Computed:    true,
-				Description: "The Network Interface's crn.",
+				Description: "The network interface's crn.",
 				Type:        schema.TypeString,
 			},
 			Attr_Instance: {
 				Computed:    true,
-				Description: "The attached instance to this Network Interface.",
+				Description: "The attached instance to this network interface.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						Attr_Href: {
@@ -92,8 +91,15 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 			},
 			Attr_NetworkSecurityGroupID: {
 				Computed:    true,
-				Description: "ID of the Network Security Group the network interface will be added to.",
+				Deprecated:  "Deprecated, use network_security_group_ids instead.",
+				Description: "ID of the network security group the network interface will be added to.",
 				Type:        schema.TypeString,
+			},
+			Attr_NetworkSecurityGroupIDs: {
+				Computed:    true,
+				Description: "List of network security groups that the network interface is a member of.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
 			},
 			Attr_Status: {
 				Computed:    true,
@@ -132,7 +138,7 @@ func dataSourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.Resource
 	d.Set(Attr_Name, networkInterface.Name)
 	d.Set(Attr_NetworkInterfaceID, *networkInterface.ID)
 	d.Set(Attr_NetworkSecurityGroupID, networkInterface.NetworkSecurityGroupID)
-
+	d.Set(Attr_NetworkSecurityGroupIDs, networkInterface.NetworkSecurityGroupIDs)
 	if networkInterface.Instance != nil {
 		instance := []map[string]interface{}{}
 		instanceMap := pvmInstanceToMap(networkInterface.Instance)

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -99,7 +99,7 @@ func DataSourceIBMPINetworkInterface() *schema.Resource {
 				Computed:    true,
 				Description: "List of network security groups that the network interface is a member of.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 			},
 			Attr_Status: {
 				Computed:    true,

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -40,22 +40,22 @@ func DataSourceIBMPINetworkInterfaces() *schema.Resource {
 			// Attributes
 			Attr_Interfaces: {
 				Computed:    true,
-				Description: "Network Interfaces.",
+				Description: "Network interfaces.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						Attr_CRN: {
 							Computed:    true,
-							Description: "The Network Interface's crn.",
+							Description: "The network interface's crn.",
 							Type:        schema.TypeString,
 						},
 						Attr_ID: {
 							Computed:    true,
-							Description: "The unique Network Interface ID.",
+							Description: "The unique network interface ID.",
 							Type:        schema.TypeString,
 						},
 						Attr_Instance: {
 							Computed:    true,
-							Description: "The attached instance to this Network Interface.",
+							Description: "The attached instance to this network interface.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									Attr_Href: {
@@ -74,23 +74,30 @@ func DataSourceIBMPINetworkInterfaces() *schema.Resource {
 						},
 						Attr_IPAddress: {
 							Computed:    true,
-							Description: "The ip address of this Network Interface.",
+							Description: "The ip address of this network interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_MacAddress: {
 							Computed:    true,
-							Description: "The mac address of the Network Interface.",
+							Description: "The mac address of the network interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_Name: {
 							Computed:    true,
-							Description: "Name of the Network Interface (not unique or indexable).",
+							Description: "Name of the network interface (not unique or indexable).",
 							Type:        schema.TypeString,
 						},
 						Attr_NetworkSecurityGroupID: {
 							Computed:    true,
-							Description: "ID of the Network Security Group the network interface will be added to.",
+							Deprecated:  "Deprecated, use network_security_group_ids instead.",
+							Description: "ID of the network security group the network interface will be added to.",
 							Type:        schema.TypeString,
+						},
+						Attr_NetworkSecurityGroupIDs: {
+							Computed:    true,
+							Description: "List of network security groups that the network interface is a member of.",
+							Elem:        &schema.Schema{Type: schema.TypeString},
+							Type:        schema.TypeList,
 						},
 						Attr_Status: {
 							Computed:    true,
@@ -148,6 +155,7 @@ func networkInterfaceToMap(netInterface *models.NetworkInterface, meta interface
 	interfaceMap[Attr_MacAddress] = netInterface.MacAddress
 	interfaceMap[Attr_Name] = netInterface.Name
 	interfaceMap[Attr_NetworkSecurityGroupID] = netInterface.NetworkSecurityGroupID
+	interfaceMap[Attr_NetworkSecurityGroupIDs] = netInterface.NetworkSecurityGroupIDs
 	if netInterface.Instance != nil {
 		pvmInstanceMap := pvmInstanceToMap(netInterface.Instance)
 		interfaceMap[Attr_Instance] = []map[string]interface{}{pvmInstanceMap}

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -101,7 +101,7 @@ func DataSourceIBMPINetworkInterfaces() *schema.Resource {
 						},
 						Attr_Status: {
 							Computed:    true,
-							Description: "The status of the network address group.",
+							Description: "The status of the network interface.",
 							Type:        schema.TypeString,
 						},
 						Attr_UserTags: {

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -97,7 +97,7 @@ func DataSourceIBMPINetworkInterfaces() *schema.Resource {
 							Computed:    true,
 							Description: "List of network security groups that the network interface is a member of.",
 							Elem:        &schema.Schema{Type: schema.TypeString},
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 						},
 						Attr_Status: {
 							Computed:    true,

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -345,6 +345,7 @@ const (
 	Attr_NetworkPorts                                = "network_ports"
 	Attr_Networks                                    = "networks"
 	Attr_NetworkSecurityGroupID                      = "network_security_group_id"
+	Attr_NetworkSecurityGroupIDs                     = "network_security_group_ids"
 	Attr_NetworkSecurityGroupMemberID                = "network_security_group_member_id"
 	Attr_NetworkSecurityGroups                       = "network_security_groups"
 	Attr_NumberOfVolumes                             = "number_of_volumes"

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -1727,7 +1727,7 @@ func createPVMInstance(d *schema.ResourceData, client *instance.IBMPIInstanceCli
 		SysType:                 systype,
 		ImageID:                 flex.PtrToString(imageid),
 		ProcType:                flex.PtrToString(processortype),
-		Replicants:              replicants,
+		Replicants:              &replicants,
 		UserData:                encodeBase64(userData),
 		ReplicantNamingScheme:   flex.PtrToString(replicationNamingScheme),
 		ReplicantAffinityPolicy: flex.PtrToString(replicationpolicy),

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -52,18 +52,18 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 				ValidateFunc: validation.NoZeroValues,
 			},
 			Arg_InstanceID: {
-				Description: "If supplied populated it attaches to the InstanceID, if empty detaches from InstanceID.",
+				Description: "If supplied populated it attaches to the instance ID, if empty detaches from the instance ID.",
 				Optional:    true,
 				Type:        schema.TypeString,
 			},
 			Arg_IPAddress: {
-				Description: "The requested IP address of this Network Interface.",
+				Description: "The requested IP address of this network interface.",
 				ForceNew:    true,
 				Optional:    true,
 				Type:        schema.TypeString,
 			},
 			Arg_Name: {
-				Description: "Name of the Network Interface.",
+				Description: "Name of the network interface.",
 				Optional:    true,
 				Type:        schema.TypeString,
 			},
@@ -85,13 +85,13 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 			// Attributes
 			Attr_CRN: {
 				Computed:    true,
-				Description: "The Network Interface's crn.",
+				Description: "The network interface's crn.",
 				Type:        schema.TypeString,
 			},
 			Attr_Instance: {
 				Computed:    true,
 				Optional:    true,
-				Description: "The attached instance to this Network Interface.",
+				Description: "The attached instance to this network interface.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						Attr_Href: {
@@ -110,17 +110,17 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 			},
 			Attr_IPAddress: {
 				Computed:    true,
-				Description: "The ip address of this Network Interface.",
+				Description: "The ip address of this network interface.",
 				Type:        schema.TypeString,
 			},
 			Attr_MacAddress: {
 				Computed:    true,
-				Description: "The mac address of the Network Interface.",
+				Description: "The mac address of the network interface.",
 				Type:        schema.TypeString,
 			},
 			Attr_Name: {
 				Computed:    true,
-				Description: "Name of the Network Interface (not unique or indexable).",
+				Description: "Name of the network interface (not unique or indexable).",
 				Type:        schema.TypeString,
 			},
 			Attr_NetworkInterfaceID: {
@@ -130,8 +130,15 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 			},
 			Attr_NetworkSecurityGroupID: {
 				Computed:    true,
-				Description: "ID of the Network Security Group the network interface will be added to.",
+				Deprecated:  "Deprecated, use network_security_group_ids instead.",
+				Description: "ID of the network security group the network interface will be added to.",
 				Type:        schema.TypeString,
+			},
+			Attr_NetworkSecurityGroupIDs: {
+				Computed:    true,
+				Description: "List of network security groups that the network interface is a member of.",
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Type:        schema.TypeList,
 			},
 			Attr_Status: {
 				Computed:    true,
@@ -220,6 +227,7 @@ func resourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.ResourceDa
 	d.Set(Attr_Name, networkInterface.Name)
 	d.Set(Attr_NetworkInterfaceID, networkInterface.ID)
 	d.Set(Attr_NetworkSecurityGroupID, networkInterface.NetworkSecurityGroupID)
+	d.Set(Attr_NetworkSecurityGroupIDs, networkInterface.NetworkSecurityGroupIDs)
 	if networkInterface.Instance != nil {
 		pvmInstance := []map[string]interface{}{}
 		instanceMap := pvmInstanceToMap(networkInterface.Instance)

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -142,7 +142,7 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 			},
 			Attr_Status: {
 				Computed:    true,
-				Description: "The status of the network address group.",
+				Description: "The status of the network interface.",
 				Type:        schema.TypeString,
 			},
 		},

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -138,7 +138,7 @@ func ResourceIBMPINetworkInterface() *schema.Resource {
 				Computed:    true,
 				Description: "List of network security groups that the network interface is a member of.",
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Type:        schema.TypeList,
+				Type:        schema.TypeSet,
 			},
 			Attr_Status: {
 				Computed:    true,

--- a/ibm/service/power/resource_ibm_pi_network_interface_test.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface_test.go
@@ -42,7 +42,6 @@ func TestAccIBMPINetworkInterfaceBasic(t *testing.T) {
 }
 
 func TestAccIBMPINetworkInterfaceAllArgs(t *testing.T) {
-
 	name := fmt.Sprintf("tf-pi-name-%d", acctest.RandIntRange(10, 100))
 	nameUpdate := fmt.Sprintf("tf-pi-name-update-%d", acctest.RandIntRange(10, 100))
 	userTags := `["tf-ni-tag-1", "tf-ni-tag-2"]`
@@ -85,7 +84,6 @@ func testAccCheckIBMPINetworkInterfaceConfigBasic(name string) string {
 
 func testAccCheckIBMPINetworkInterfaceConfig(name, userTags string) string {
 	return fmt.Sprintf(`
-
 		resource "ibm_pi_network_interface" "network_interface" {
 			pi_cloud_instance_id = "%[1]s"
 			pi_network_id = "%[2]s"
@@ -95,7 +93,6 @@ func testAccCheckIBMPINetworkInterfaceConfig(name, userTags string) string {
 }
 
 func testAccCheckIBMPINetworkInterfaceExists(n string) resource.TestCheckFunc {
-
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -120,7 +117,6 @@ func testAccCheckIBMPINetworkInterfaceExists(n string) resource.TestCheckFunc {
 			return err
 		}
 		return nil
-
 	}
 }
 
@@ -143,6 +139,5 @@ func testAccCheckIBMPINetworkInterfaceDestroy(s *terraform.State) error {
 			return fmt.Errorf("pi_network_interface still exists: %s", rs.Primary.ID)
 		}
 	}
-
 	return nil
 }

--- a/website/docs/d/pi_network_interface.html.markdown
+++ b/website/docs/d/pi_network_interface.html.markdown
@@ -60,5 +60,5 @@ In addition to all argument reference list, you can access the following attribu
 - `name` - (String) Name of the network interface (not unique or indexable).
 - `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
 - `network_interface_id` - (String) The unique identifier of the network interface.
-- `status` - (String) The status of the network address group.
+- `status` - (String) The status of the network interface.
 - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/d/pi_network_interface.html.markdown
+++ b/website/docs/d/pi_network_interface.html.markdown
@@ -58,6 +58,7 @@ In addition to all argument reference list, you can access the following attribu
 - `ip_address` - (String) The ip address of this network interface.
 - `mac_address` - (String) The mac address of the network interface.
 - `name` - (String) Name of the network interface (not unique or indexable).
+- `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
 - `network_interface_id` - (String) The unique identifier of the network interface.
 - `status` - (String) The status of the network address group.
 - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/d/pi_network_interfaces.html.markdown
+++ b/website/docs/d/pi_network_interfaces.html.markdown
@@ -48,12 +48,12 @@ Review the argument references that you can specify for your data source.
 In addition to all argument reference listed, you can access the following attribute references after your data source is created.
 
 - `id` - (String) The unique identifier of the pi_network_interfaces.
-- `interfaces` - (List) network Interfaces.
+- `interfaces` - (List) Network interfaces.
   
   Nested scheme for `interfaces`:
   - `crn` - (String) The network interface's crn.
   - `id` - (String) The unique network interface id.
-  - `instance` - (List) The attached instance to this Network Interface.
+  - `instance` - (List) The attached instance to this network interface.
 
       Nested scheme for `instance`:
         - `href` - (String) Link to instance resource.
@@ -61,5 +61,6 @@ In addition to all argument reference listed, you can access the following attri
   - `ip_address` - (String) The ip address of this network interface.
   - `mac_address` - (String) The mac address of the network interface.
   - `name` - (String) Name of the network interface (not unique or indexable).
+  - `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
   - `status` - (String) The status of the network address group.
   - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/d/pi_network_interfaces.html.markdown
+++ b/website/docs/d/pi_network_interfaces.html.markdown
@@ -62,5 +62,5 @@ In addition to all argument reference listed, you can access the following attri
   - `mac_address` - (String) The mac address of the network interface.
   - `name` - (String) Name of the network interface (not unique or indexable).
   - `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
-  - `status` - (String) The status of the network address group.
+  - `status` - (String) The status of the network interface.
   - `user_tags` - (List) List of user tags attached to the resource.

--- a/website/docs/r/pi_network_interface.html.markdown
+++ b/website/docs/r/pi_network_interface.html.markdown
@@ -49,7 +49,7 @@ The `ibm_pi_network` provides the following [Timeouts](https://www.terraform.io/
 Review the argument references that you can specify for your resource.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_id` - (Optional, String) If supplied populated it attaches to the InstanceID, if empty detaches from InstanceID.
+- `pi_instance_id` - (Optional, String) If supplied populated it attaches to the instance ID, if empty detaches from the instance ID.
 - `pi_ip_address` - (Optional, String) The requested IP address of this network interface.
 - `pi_name` - (Optional, String) Name of the network interface.
 - `pi_network_id` - (Required, String) network id.
@@ -61,7 +61,7 @@ In addition to all argument reference list, you can access the following attribu
 
 - `crn` - (String) The network interface's crn.
 - `id` - (String) The unique identifier of the network interface resource. The ID is composed of `<cloud_instance_id>/<network_id>/<network_interface_id>`.
-- `instance` - (List) The attached instance to this Network Interface.
+- `instance` - (List) The attached instance to this network interface.
 
   Nested scheme for `instance`:
   - `href` - (String) Link to instance resource.
@@ -70,7 +70,8 @@ In addition to all argument reference list, you can access the following attribu
 - `mac_address` - (String) The mac address of the network interface.
 - `name` - (String) Name of the network interface (not unique or indexable).
 - `network_interface_id` - (String) The unique identifier of the network interface.
-- `network_security_group_id` - (String) ID of the Network Security Group the network interface will be added to.
+- `network_security_group_id` - (Deprecated, String) ID of the network security group the network interface will be added to. Please use network_security_group_ids instead.
+- `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
 - `status` - (String) The status of the network address group.
 
 ## Import

--- a/website/docs/r/pi_network_interface.html.markdown
+++ b/website/docs/r/pi_network_interface.html.markdown
@@ -72,7 +72,7 @@ In addition to all argument reference list, you can access the following attribu
 - `network_interface_id` - (String) The unique identifier of the network interface.
 - `network_security_group_id` - (Deprecated, String) ID of the network security group the network interface will be added to. Please use network_security_group_ids instead.
 - `network_security_group_ids` - (List) List of network security groups that the network interface is a member of.
-- `status` - (String) The status of the network address group.
+- `status` - (String) The status of the network interface.
 
 ## Import
 

--- a/website/docs/r/pi_network_security_group.html.markdown
+++ b/website/docs/r/pi_network_security_group.html.markdown
@@ -47,7 +47,7 @@ Example usage:
 Review the argument references that you can specify for your resource.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_name` - (Required, String) The name of the Network Security Group.
+- `pi_name` - (Required, String) The name of the network security group.
 - `pi_user_tags` - (Optional, List) A list of tags.
 
 ## Attribute Reference
@@ -84,7 +84,7 @@ In addition to all argument reference list, you can access the following attribu
   - `remote` - (List) List of remote.
 
       Nested schema for `remote`:
-        - `id` - (String) The id of the remote network Address group or network security group the rules apply to. Not required for default-network-address-group.
+        - `id` - (String) The id of the remote network address group or network security group the rules apply to. Not required for default-network-address-group.
         - `type` - (String) The type of remote group the rules apply to. Supported values are: `network-security-group`, `network-address-group`, `default-network-address-group`.
   - `source_port` - (List) List of source port
 


### PR DESCRIPTION
Output from acceptance tests:

data source network interface
```
--- PASS: TestAccIBMPINetworkInterfaceDataSourceBasic (16.07s)
PASS
```

data source network interfaces
```
--- PASS: TestAccIBMPINetworkInterfacesDataSourceBasic (16.60s)
PASS
```

resource network interface
```
--- PASS: TestAccIBMPINetworkInterfaceBasic (23.25s)
PASS

--- PASS: TestAccIBMPINetworkInterfaceAllArgs (34.87s)
PASS
```