### PR TITLE
Revert pi_image_name restrictions

### DIFF
--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -141,11 +141,12 @@ func ResourceIBMPIImage() *schema.Resource {
 				Type:          schema.TypeString,
 			},
 			Arg_ImageName: {
-				Description:  "Image name",
-				ForceNew:     true,
-				Optional:     true,
-				Type:         schema.TypeString,
-				ValidateFunc: validation.NoZeroValues,
+				Description:      "Image name",
+				DiffSuppressFunc: flex.ApplyOnce,
+				ForceNew:         true,
+				Optional:         true,
+				Type:             schema.TypeString,
+				ValidateFunc:     validation.NoZeroValues,
 			},
 			Arg_ImageSecretKey: {
 				Description:  "Cloud Object Storage secret key; required for buckets with private access",

--- a/ibm/service/power/resource_ibm_pi_image.go
+++ b/ibm/service/power/resource_ibm_pi_image.go
@@ -121,7 +121,7 @@ func ResourceIBMPIImage() *schema.Resource {
 				ExactlyOneOf:  []string{Arg_ImageID, Arg_ImageBucketName},
 				ForceNew:      true,
 				Optional:      true,
-				RequiredWith:  []string{Arg_ImageBucketRegion, Arg_ImageBucketFileName, Arg_ImageName},
+				RequiredWith:  []string{Arg_ImageBucketRegion, Arg_ImageBucketFileName},
 				Type:          schema.TypeString,
 			},
 			Arg_ImageBucketRegion: {
@@ -141,11 +141,9 @@ func ResourceIBMPIImage() *schema.Resource {
 				Type:          schema.TypeString,
 			},
 			Arg_ImageName: {
-				Computed:     true,
 				Description:  "Image name",
 				ForceNew:     true,
 				Optional:     true,
-				RequiredWith: []string{Arg_ImageBucketName},
 				Type:         schema.TypeString,
 				ValidateFunc: validation.NoZeroValues,
 			},
@@ -403,7 +401,6 @@ func resourceIBMPIImageRead(ctx context.Context, d *schema.ResourceData, meta in
 	}
 	d.Set(Arg_CloudInstanceID, cloudInstanceID)
 	d.Set(Attr_ImageID, imageid)
-	d.Set(Arg_ImageName, imagedata.Name)
 
 	return nil
 }

--- a/ibm/service/power/resource_ibm_pi_image_test.go
+++ b/ibm/service/power/resource_ibm_pi_image_test.go
@@ -95,6 +95,7 @@ func testAccCheckIBMPIImageConfig() string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_image" "power_image" {
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name		= "power_image"
 		pi_image_id         = "%[2]s"
 	  }
 	`, acc.Pi_cloud_instance_id, acc.Pi_image)
@@ -174,6 +175,7 @@ func testAccCheckIBMPIImageUserTagsConfig(userTagsString string) string {
 	return fmt.Sprintf(`
 	resource "ibm_pi_image" "power_image" {
 		pi_cloud_instance_id = "%[1]s"
+		pi_image_name		= "power_image"
 		pi_image_id         = "%[2]s"
 		pi_user_tags        = %[3]s
 	  }

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -85,7 +85,7 @@ Review the argument references that you can specify for your resource.
   - You can retrieve this value from [pi_catalog_images](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/pi_catalog_images#image_id) as `image_id` from the stock image you intend to use.
 - `pi_image_name` - (Optional, String) The name of an image for importing only. Required if importing from bucket.
 
-    ~> **NOTE** will  be required with `pi_image_bucket_name` and conflict with `pi_image_id` in future releases.
+    ~> **NOTE** will  be required with `pi_image_bucket_name` and conflict with `pi_image_id` in future releases. Currently has no effect if copying from catalog.
 - `pi_image_secret_key` - (Optional, String, Sensitive) Cloud Object Storage secret key; required for buckets with private access.
   - `pi_image_secret_key` is required with `pi_image_access_key`
 - `pi_image_storage_pool` - (Optional, String) Storage pool where the image will be loaded, if provided then `pi_affinity_policy` will be ignored. Used only when importing an image from cloud storage.

--- a/website/docs/r/pi_image.html.markdown
+++ b/website/docs/r/pi_image.html.markdown
@@ -18,7 +18,6 @@ The following example enables you to create a image in your project:
 
 ```terraform
 resource "ibm_pi_image" "testacc_image  "{
-  pi_image_name       = "7200-03-02"
   pi_image_id         = <"image id obtained from the datasource">
   pi_cloud_instance_id = "<value of the cloud_instance_id>"
 }
@@ -84,7 +83,9 @@ Review the argument references that you can specify for your resource.
 - `pi_image_id` - (Optional, String) Image ID of existing source image; required for copy image.
   - Either `pi_image_id` or `pi_image_bucket_name` is required.
   - You can retrieve this value from [pi_catalog_images](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/pi_catalog_images#image_id) as `image_id` from the stock image you intend to use.
-- `pi_image_name` - (Optional, String) The name of an image for importing only. Required if importing from bucket. Conflicts with `pi_image_id`.
+- `pi_image_name` - (Optional, String) The name of an image for importing only. Required if importing from bucket.
+
+    ~> **NOTE** will  be required with `pi_image_bucket_name` and conflict with `pi_image_id` in future releases.
 - `pi_image_secret_key` - (Optional, String, Sensitive) Cloud Object Storage secret key; required for buckets with private access.
   - `pi_image_secret_key` is required with `pi_image_access_key`
 - `pi_image_storage_pool` - (Optional, String) Storage pool where the image will be loaded, if provided then `pi_affinity_policy` will be ignored. Used only when importing an image from cloud storage.


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance tests:

```
=== RUN   TestAccIBMPIImagebasic
--- PASS: TestAccIBMPIImagebasic (64.44s)
PASS

=== RUN   TestAccIBMPIImageUserTags
--- PASS: TestAccIBMPIImageUserTags (97.92s)
PASS

=== RUN   TestAccIBMPIImageBYOLImport
--- PASS: TestAccIBMPIImageBYOLImport (1337.29s)
PASS

=== RUN   TestAccIBMPIImageCOSPublicImport
--- PASS: TestAccIBMPIImageCOSPublicImport (522.83s)
PASS
```