### PR TITLE
Deprecate network port data source and resource

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_network_port.go
+++ b/ibm/service/power/data_source_ibm_pi_network_port.go
@@ -86,6 +86,7 @@ func DataSourceIBMPINetworkPort() *schema.Resource {
 				},
 			},
 		},
+		DeprecationMessage: "Data Source ibm_pi_network_port_attach is deprecated.",
 	}
 }
 

--- a/ibm/service/power/resource_ibm_pi_network_port_attach.go
+++ b/ibm/service/power/resource_ibm_pi_network_port_attach.go
@@ -105,6 +105,7 @@ func ResourceIBMPINetworkPortAttach() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 		},
+		DeprecationMessage: "Resource ibm_pi_network_port_attach is deprecated.",
 	}
 
 }

--- a/website/docs/d/pi_network_port.html.markdown
+++ b/website/docs/d/pi_network_port.html.markdown
@@ -8,6 +8,8 @@ description: |-
 
 # ibm_pi_network_port
 
+~> This resource is deprecated and will be removed in the next major version.
+
 Retrieve information about a network port in the Power Virtual Server Cloud. For more information, about networks in IBM power virtual server, see [adding or removing a public network](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-modifying-server#adding-removing-network).
 
 ## Example usage

--- a/website/docs/r/pi_network_port_attach.html.markdown
+++ b/website/docs/r/pi_network_port_attach.html.markdown
@@ -9,6 +9,8 @@ description: |-
 
 # ibm_pi_network_port_attach
 
+~> This resource is deprecated and will be removed in the next major version.
+
 Attaches a network port to a Power Systems Virtual Server instance. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
 ## Example usage


### PR DESCRIPTION
Deprecate network port data source and resource.

![Screenshot 2025-02-11 at 1 35 02 PM](https://github.com/user-attachments/assets/ecd808ce-62cb-4bea-8abb-ac5957fef490)
