### PR TITLE
Deprecate CRN attribute from ibm_pi_volume_snapshot(s)

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_volume_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_snapshot.go
@@ -40,6 +40,7 @@ func DataSourceIBMPIVolumeSnapshot() *schema.Resource {
 			},
 			Attr_CRN: {
 				Computed:    true,
+				Deprecated:  "This field is deprecated.",
 				Description: "The CRN of the volume snapshot.",
 				Type:        schema.TypeString,
 			},

--- a/ibm/service/power/data_source_ibm_pi_volume_snapshots.go
+++ b/ibm/service/power/data_source_ibm_pi_volume_snapshots.go
@@ -41,6 +41,7 @@ func DataSourceIBMPIVolumeSnapshots() *schema.Resource {
 						},
 						Attr_CRN: {
 							Computed:    true,
+							Deprecated:  "This field is deprecated.",
 							Description: "The CRN of the volume snapshot.",
 							Type:        schema.TypeString,
 						},

--- a/website/docs/d/pi_volume_snapshot.html.markdown
+++ b/website/docs/d/pi_volume_snapshot.html.markdown
@@ -47,7 +47,7 @@ You can specify the following arguments for this data source.
 In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `creation_date` - (String) The date and time when the volume snapshot was created.
-- `crn` - (String) The CRN for this resource.
+- `crn` - (Deprecated, String) The CRN for this resource.
 - `id` - (String) The unique identifier of the volume snapshot.
 - `name` - (String) The volume snapshot name.
 - `size` - (Float) The size of the volume snapshot, in gibibytes (GiB).

--- a/website/docs/d/pi_volume_snapshots.html.markdown
+++ b/website/docs/d/pi_volume_snapshots.html.markdown
@@ -48,7 +48,7 @@ In addition to all argument reference list, you can access the following attribu
 
   Nested schema for `volume_snapshots`:
   - `creation_date` - (String) The date and time when the volume snapshot was created.
-  - `crn` - (String) The CRN of the volume snapshot.
+  - `crn` - (Deprecated, String) The CRN of the volume snapshot.
   - `id` - (String) The volume snapshot UUID.
   - `name` - (String) The volume snapshot name.
   - `size` - (Float) The size of the volume snapshot, in gibibytes (GiB).


### PR DESCRIPTION
This field was mistakenly added and is not and has never been filled out by the service broker. It currently only applies to the instance_snapshot data source and resource.

Output from acceptance testing

```
--- PASS: TestAccIBMPIVolumeSnapshotsDataSourceBasic (16.48s)
PASS

--- PASS: TestAccIBMPIVolumeSnapshotDataSourceBasic (16.28s)
PASS
```