### PR TITLE
[Datasource] Fix crash when vm has no volumes

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -153,7 +153,10 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 
 	var clientgenU, _ = uuid.GenerateUUID()
 	d.SetId(clientgenU)
-	d.Set(Attr_BootVolumeID, *volumedata.Volumes[0].VolumeID)
+	if len(volumedata.Volumes) > 0 {
+		d.Set(Attr_BootVolumeID, *volumedata.Volumes[0].VolumeID)
+	}
+
 	d.Set(Attr_InstanceVolumes, flattenVolumesInstances(volumedata.Volumes, meta))
 
 	return nil
@@ -162,7 +165,6 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, len(list))
 	for _, i := range list {
-
 		l := map[string]interface{}{
 			Attr_Bootable:           *i.Bootable,
 			Attr_CreationDate:       i.CreationDate.String(),
@@ -191,7 +193,6 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) [
 		if len(i.ReplicationSites) > 0 {
 			l[Attr_ReplicationSites] = i.ReplicationSites
 		}
-
 		result = append(result, l)
 	}
 	return result


### PR DESCRIPTION
This crash occurred because the vm has no volumes and we tried to list them. I think this changed within the last year, and it is now possible to have a vm with no volumes.

Output from acceptance testing:
```
--- PASS: TestAccIBMPIVolumesDataSource_basic (28.58s)
PASS
```