### PR TITLE
[Resource] Remove computed property from pi_instance "pi_placement_group_id" and fix placement group acceptance test

### DIFF
--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -232,7 +232,6 @@ func ResourceIBMPIInstance() *schema.Resource {
 			},
 			Arg_PlacementGroupID: {
 				Description: "Placement group ID",
-				Computed:    true,
 				Optional:    true,
 				Type:        schema.TypeString,
 			},


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000


Description: 
`Computed: true` was erroneously added to `pi_placement_group_id` argument  in `pi_instance` resource refactor. This resulted in the placement group acceptance tests failing and a slight behavior change. This PR removes that property and fixes errors in placement group acceptance tests.

Instance refactor PR: https://github.com/IBM-Cloud/terraform-provider-ibm/pull/5385

Output from acceptance testing:
```
--- PASS: TestAccIBMPIInstanceBasic (1267.70s)
PASS

--- PASS: TestAccIBMPIPlacementGroupBasic (4442.97s)
PASS
```
