### PR TITLE
[Datasource] Replace GetTagsUsingCRN with GetGlobalTagsUsingCRN

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_hosts.go
@@ -163,7 +163,7 @@ func dataSourceIBMPIHostsRead(ctx context.Context, d *schema.ResourceData, meta 
 			}
 			if host.Crn != "" {
 				hs[Attr_CRN] = host.Crn
-				tags, err := flex.GetTagsUsingCRN(meta, string(host.Crn))
+				tags, err := flex.GetGlobalTagsUsingCRN(meta, string(host.Crn), "", UserTagType)
 				if err != nil {
 					log.Printf("Error on get of pi host (%s) user_tags: %s", host.ID, err)
 				}

--- a/ibm/service/power/data_source_ibm_pi_image.go
+++ b/ibm/service/power/data_source_ibm_pi_image.go
@@ -113,7 +113,7 @@ func dataSourceIBMPIImagesRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_Architecture, imagedata.Specifications.Architecture)
 	if imagedata.Crn != "" {
 		d.Set(Attr_CRN, imagedata.Crn)
-		tags, err := flex.GetTagsUsingCRN(meta, string(imagedata.Crn))
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, string(imagedata.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi image (%s) user_tags: %s", *imagedata.ImageID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_images.go
+++ b/ibm/service/power/data_source_ibm_pi_images.go
@@ -132,7 +132,7 @@ func flattenStockImages(list []*models.ImageReference, meta interface{}) []map[s
 		}
 		if i.Crn != "" {
 			l[Attr_CRN] = i.Crn
-			tags, err := flex.GetTagsUsingCRN(meta, string(i.Crn))
+			tags, err := flex.GetGlobalTagsUsingCRN(meta, string(i.Crn), "", UserTagType)
 			if err != nil {
 				log.Printf(
 					"Error on get of image (%s) user_tags: %s", *i.ImageID, err)

--- a/ibm/service/power/data_source_ibm_pi_network_address_group.go
+++ b/ibm/service/power/data_source_ibm_pi_network_address_group.go
@@ -91,7 +91,7 @@ func dataSourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.Resou
 	d.SetId(*networkAddressGroup.ID)
 	if networkAddressGroup.Crn != nil {
 		d.Set(Attr_CRN, networkAddressGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkAddressGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkAddressGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi network address group (%s) user_tags: %s", nagID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_network_address_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_network_address_groups.go
@@ -117,7 +117,7 @@ func networkAddressGroupsNetworkAddressGroupToMap(networkAddressGroup *models.Ne
 	nag := make(map[string]interface{})
 	if networkAddressGroup.Crn != nil {
 		nag[Attr_CRN] = networkAddressGroup.Crn
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkAddressGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkAddressGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi network address group (%s) user_tags: %s", *networkAddressGroup.ID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_network_interface.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interface.go
@@ -148,7 +148,7 @@ func dataSourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.Resource
 	d.Set(Attr_Status, networkInterface.Status)
 	if networkInterface.Crn != nil {
 		d.Set(Attr_CRN, networkInterface.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkInterface.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkInterface.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network interface (%s) user_tags: %s", *networkInterface.ID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_network_interfaces.go
+++ b/ibm/service/power/data_source_ibm_pi_network_interfaces.go
@@ -163,7 +163,7 @@ func networkInterfaceToMap(netInterface *models.NetworkInterface, meta interface
 	interfaceMap[Attr_Status] = netInterface.Status
 	if netInterface.Crn != nil {
 		interfaceMap[Attr_CRN] = netInterface.Crn
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*netInterface.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*netInterface.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network interface (%s) user_tags: %s", *netInterface.ID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_network_security_group.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_group.go
@@ -222,7 +222,7 @@ func dataSourceIBMPINetworkSecurityGroupRead(ctx context.Context, d *schema.Reso
 	d.SetId(*networkSecurityGroup.ID)
 	if networkSecurityGroup.Crn != nil {
 		d.Set(Attr_CRN, networkSecurityGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkSecurityGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkSecurityGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi network security group (%s) user_tags: %s", *networkSecurityGroup.ID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_network_security_groups.go
+++ b/ibm/service/power/data_source_ibm_pi_network_security_groups.go
@@ -247,7 +247,7 @@ func networkSecurityGroupToMap(nsg *models.NetworkSecurityGroup, meta interface{
 	networkSecurityGroup := make(map[string]interface{})
 	if nsg.Crn != nil {
 		networkSecurityGroup[Attr_CRN] = nsg.Crn
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*nsg.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*nsg.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi network security group (%s) user_tags: %s", *nsg.ID, err)
 		}

--- a/ibm/service/power/data_source_ibm_pi_volume.go
+++ b/ibm/service/power/data_source_ibm_pi_volume.go
@@ -182,7 +182,7 @@ func dataSourceIBMPIVolumeRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set(Attr_CreationDate, volumedata.CreationDate.String())
 	if volumedata.Crn != "" {
 		d.Set(Attr_CRN, volumedata.Crn)
-		tags, err := flex.GetTagsUsingCRN(meta, string(volumedata.Crn))
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, string(volumedata.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi volume (%s) user_tags: %s", *volumedata.VolumeID, err)
 		}

--- a/ibm/service/power/resource_ibm_pi_instance.go
+++ b/ibm/service/power/resource_ibm_pi_instance.go
@@ -609,7 +609,7 @@ func resourceIBMPIInstanceRead(ctx context.Context, d *schema.ResourceData, meta
 
 	if powervmdata.Crn != "" {
 		d.Set(Attr_CRN, powervmdata.Crn)
-		tags, err := flex.GetTagsUsingCRN(meta, string(powervmdata.Crn))
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, string(powervmdata.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of ibm pi instance (%s) pi_user_tags: %s", *powervmdata.PvmInstanceID, err)
 		}

--- a/ibm/service/power/resource_ibm_pi_network_address_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group.go
@@ -153,7 +153,7 @@ func resourceIBMPINetworkAddressGroupRead(ctx context.Context, d *schema.Resourc
 	d.Set(Arg_Name, networkAddressGroup.Name)
 	if networkAddressGroup.Crn != nil {
 		d.Set(Attr_CRN, networkAddressGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkAddressGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkAddressGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network address group (%s) pi_user_tags: %s", nagID, err)
 		}

--- a/ibm/service/power/resource_ibm_pi_network_address_group_member.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group_member.go
@@ -160,7 +160,7 @@ func resourceIBMPINetworkAddressGroupMemberRead(ctx context.Context, d *schema.R
 
 	if networkAddressGroup.Crn != nil {
 		d.Set(Attr_CRN, networkAddressGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkAddressGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkAddressGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of pi network address group (%s) user_tags: %s", parts[1], err)
 		}

--- a/ibm/service/power/resource_ibm_pi_network_interface.go
+++ b/ibm/service/power/resource_ibm_pi_network_interface.go
@@ -239,7 +239,7 @@ func resourceIBMPINetworkInterfaceRead(ctx context.Context, d *schema.ResourceDa
 	d.Set(Attr_Status, networkInterface.Status)
 	if networkInterface.Crn != nil {
 		d.Set(Attr_CRN, networkInterface.Crn)
-		tags, err := flex.GetTagsUsingCRN(meta, string(*networkInterface.Crn))
+		tags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkInterface.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network interface (%s) pi_user_tags: %s", *networkInterface.ID, err)
 		}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_member.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_member.go
@@ -307,7 +307,7 @@ func resourceIBMPINetworkSecurityGroupMemberRead(ctx context.Context, d *schema.
 
 	if networkSecurityGroup.Crn != nil {
 		d.Set(Attr_CRN, networkSecurityGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkSecurityGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkSecurityGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network security group (%s) user_tags: %s", parts[1], err)
 		}

--- a/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
+++ b/ibm/service/power/resource_ibm_pi_network_security_group_rule.go
@@ -500,7 +500,7 @@ func resourceIBMPINetworkSecurityGroupRuleRead(ctx context.Context, d *schema.Re
 
 	if networkSecurityGroup.Crn != nil {
 		d.Set(Attr_CRN, networkSecurityGroup.Crn)
-		userTags, err := flex.GetTagsUsingCRN(meta, string(*networkSecurityGroup.Crn))
+		userTags, err := flex.GetGlobalTagsUsingCRN(meta, string(*networkSecurityGroup.Crn), "", UserTagType)
 		if err != nil {
 			log.Printf("Error on get of network security group (%s) user_tags: %s", nsgID, err)
 		}


### PR DESCRIPTION
We were calling each of these functions about half and half, but they do literally the same thing. We should be calling only one of them for consistency and clarity.

```
--- PASS: TestAccIBMPIInstanceUserTags (1239.10s)
PASS

--- PASS: TestAccIBMPINetworkAddressGroupBasic (29.89s)
PASS

--- PASS: TestAccIBMPINetworkAddressGroupMemberBasic (45.59s)
PASS

--- PASS: TestAccIBMPINetworkInterfaceAllArgs (52.77s)
PASS
```