### PR TITLE
[Resource] pi_network_access_group fix user tags argument crash, add user tags test

### DIFF
--- a/ibm/service/power/resource_ibm_pi_network_address_group.go
+++ b/ibm/service/power/resource_ibm_pi_network_address_group.go
@@ -110,7 +110,7 @@ func resourceIBMPINetworkAddressGroupCreate(ctx context.Context, d *schema.Resou
 	}
 
 	if v, ok := d.GetOk(Arg_UserTags); ok {
-		body.UserTags = flex.ExpandStringList(v.([]interface{}))
+		body.UserTags = flex.FlattenSet(v.(*schema.Set))
 	}
 
 	networkAddressGroup, err := nagC.Create(body)


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/IBM-Cloud/terraform-provider-ibm/blob/master/.github/CONTRIBUTING.md --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
Relates OR Closes #0000

Output from acceptance testing:

```
--- PASS: TestAccIBMPINetworkAddressGroupUserTags (47.95s)
PASS

--- PASS: TestAccIBMPINetworkAddressGroupBasic (34.42s)
PASS
```
