### PR TITLE
Refactor terraform errors to use new toolchain

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_available_hosts.go
+++ b/ibm/service/power/data_source_ibm_pi_available_hosts.go
@@ -5,10 +5,12 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
-
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -63,13 +65,17 @@ func DataSourceIBMPIAvailableHosts() *schema.Resource {
 func dataSourceIBMPIAvailableHostsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_available_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	hostClient := instance.NewIBMPIHostGroupsClient(ctx, sess, cloudInstanceID)
 	hostlist, err := hostClient.GetAvailableHosts()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAvailableHosts failed: %s", err.Error()), "(Data) ibm_pi_available_hosts", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 	availableHosts := []map[string]interface{}{}
 	for _, value := range hostlist {

--- a/ibm/service/power/data_source_ibm_pi_catalog_images.go
+++ b/ibm/service/power/data_source_ibm_pi_catalog_images.go
@@ -5,10 +5,13 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"time"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -139,7 +142,9 @@ func DataSourceIBMPICatalogImages() *schema.Resource {
 func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_catalog_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -148,7 +153,9 @@ func dataSourceIBMPICatalogImagesRead(ctx context.Context, d *schema.ResourceDat
 	imageC := instance.NewIBMPIImageClient(ctx, sess, cloudInstanceID)
 	stockImages, err := imageC.GetAllStockImages(includeSAP, includeVTL)
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAllStockImages failed: %s", err.Error()), "(Data) ibm_pi_catalog_images", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	images := make([]map[string]interface{}, 0)


### PR DESCRIPTION
This PR does it for the available hosts and catalog images data sources.

Output of acceptance tests:
```
--- PASS: TestAccIBMPIAvailableHostsDataSourceBasic (36.90s)
PASS

--- PASS: TestAccIBMPICatalogImagesDataSourceBasic (22.96s)
PASS

--- PASS: TestAccIBMPICatalogImagesDataSourceSAP (22.32s)
PASS

--- PASS: TestAccIBMPICatalogImagesDataSourceVTL (20.70s)
PASS

--- PASS: TestAccIBMPICatalogImagesDataSourceSAPAndVTL (21.87s)
PASS
```