### PR TITLE
[D][R] Add creation date attribute to shared processor pool data source and resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.2
 require (
 	github.com/IBM-Cloud/bluemix-go v0.0.0-20250324085928-caa6511f0c13
 	github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113
-	github.com/IBM-Cloud/power-go-client v1.12.0
+	github.com/IBM-Cloud/power-go-client v1.13.0-beta11
 	github.com/IBM/appconfiguration-go-admin-sdk v0.5.1
 	github.com/IBM/appid-management-go-sdk v0.0.0-20210908164609-dd0e0eaf732f
 	github.com/IBM/cloud-databases-go-sdk v0.8.0

--- a/go.sum
+++ b/go.sum
@@ -94,8 +94,8 @@ github.com/IBM-Cloud/bluemix-go v0.0.0-20250324085928-caa6511f0c13 h1:oBtZEpmwue
 github.com/IBM-Cloud/bluemix-go v0.0.0-20250324085928-caa6511f0c13/go.mod h1:/7hMjdZA6fEpd/dQAOEABxKEwN0t72P3PlpEDu0Y7bE=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113 h1:f2Erqfea1dKpaTFagTJM6W/wnD3JGq/Vn9URh8nuRwk=
 github.com/IBM-Cloud/container-services-go-sdk v0.0.0-20240725064144-454a2ae23113/go.mod h1:xUQL9SGAjoZFd4GNjrjjtEpjpkgU7RFXRyHesbKTjiY=
-github.com/IBM-Cloud/power-go-client v1.12.0 h1:tF9Mq5GLYHebpzQT6IYB89lIxEST1E9teuchjxSAaw0=
-github.com/IBM-Cloud/power-go-client v1.12.0/go.mod h1:SpTK1ttW8bfMNUVQS8qOEuWn2KOkzaCLyzfze8MG1JE=
+github.com/IBM-Cloud/power-go-client v1.13.0-beta11 h1:9DygYN7GEWt4Ds5aIf440xU73NO3qNlA8zP9olxVssI=
+github.com/IBM-Cloud/power-go-client v1.13.0-beta11/go.mod h1:SpTK1ttW8bfMNUVQS8qOEuWn2KOkzaCLyzfze8MG1JE=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf h1:koUAyF9b6X78lLLruGYPSOmrfY2YcGYKOj/Ug9nbKNw=
 github.com/IBM-Cloud/softlayer-go v1.0.5-tf/go.mod h1:6HepcfAXROz0Rf63krk5hPZyHT6qyx2MNvYyHof7ik4=
 github.com/IBM/appconfiguration-go-admin-sdk v0.5.1 h1:EAotl3yQ/u5u/uBryySJMm0COgsYhtNzQ1g2IChtlE0=

--- a/ibm/service/power/data_source_ibm_pi_network_peers.go
+++ b/ibm/service/power/data_source_ibm_pi_network_peers.go
@@ -93,9 +93,6 @@ func dataSourceIBMPINetworkPeersRead(ctx context.Context, d *schema.ResourceData
 
 func dataSourceIBMPINetworkPeersNetworkPeerToMap(np *models.NetworkPeer) map[string]interface{} {
 	npMap := make(map[string]interface{})
-	if np.Description != nil {
-		npMap[Attr_Description] = np.Description
-	}
 	if np.ID != nil {
 		npMap[Attr_ID] = np.ID
 	}

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
@@ -181,7 +181,7 @@ func dataSourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resou
 			d.Set(Attr_UserTags, tags)
 		}
 	}
-	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate)
+	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate.String())
 	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Name, response.SharedProcessorPool.Name)

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pool.go
@@ -44,6 +44,11 @@ func DataSourceIBMPISharedProcessorPool() *schema.Resource {
 				Description: "The available cores in the shared processor pool.",
 				Type:        schema.TypeFloat,
 			},
+			Attr_CreationDate: {
+				Computed:    true,
+				Description: "Date of shared processor pool creation.",
+				Type:        schema.TypeString,
+			},
 			Attr_CRN: {
 				Computed:    true,
 				Description: "The CRN of this resource.",
@@ -176,6 +181,7 @@ func dataSourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resou
 			d.Set(Attr_UserTags, tags)
 		}
 	}
+	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate)
 	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Name, response.SharedProcessorPool.Name)

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -99,7 +99,7 @@ func DataSourceIBMPISharedProcessorPools() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
 		return diag.FromErr(err)
@@ -113,9 +113,9 @@ func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.Reso
 		return diag.Errorf("error fetching shared processor pools: %v", err)
 	}
 
-	result := make([]map[string]interface{}, 0, len(pools.SharedProcessorPools))
+	result := make([]map[string]any, 0, len(pools.SharedProcessorPools))
 	for _, pool := range pools.SharedProcessorPools {
-		key := map[string]interface{}{
+		key := map[string]any{
 			Attr_AllocatedCores:        *pool.AllocatedCores,
 			Attr_AvailableCores:        *pool.AvailableCores,
 			Attr_DedicatedHostID:       pool.DedicatedHostID,

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -123,7 +123,7 @@ func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.Reso
 		key := map[string]any{
 			Attr_AllocatedCores:        *pool.AllocatedCores,
 			Attr_AvailableCores:        *pool.AvailableCores,
-			Attr_CreationDate:          *pool.CreationDate,
+			Attr_CreationDate:          pool.CreationDate.String(),
 			Attr_DedicatedHostID:       pool.DedicatedHostID,
 			Attr_HostID:                pool.HostID,
 			Attr_Name:                  *pool.Name,

--- a/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
+++ b/ibm/service/power/data_source_ibm_pi_shared_processor_pools.go
@@ -44,6 +44,11 @@ func DataSourceIBMPISharedProcessorPools() *schema.Resource {
 							Description: "The available cores in the shared processor pool.",
 							Type:        schema.TypeInt,
 						},
+						Attr_CreationDate: {
+							Computed:    true,
+							Description: "Date of shared processor pool creation.",
+							Type:        schema.TypeString,
+						},
 						Attr_CRN: {
 							Computed:    true,
 							Description: "The CRN of this resource.",
@@ -118,6 +123,7 @@ func dataSourceIBMPISharedProcessorPoolsRead(ctx context.Context, d *schema.Reso
 		key := map[string]any{
 			Attr_AllocatedCores:        *pool.AllocatedCores,
 			Attr_AvailableCores:        *pool.AvailableCores,
+			Attr_CreationDate:          *pool.CreationDate,
 			Attr_DedicatedHostID:       pool.DedicatedHostID,
 			Attr_HostID:                pool.HostID,
 			Attr_Name:                  *pool.Name,

--- a/ibm/service/power/resource_ibm_pi_instance_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_instance_snapshot.go
@@ -224,7 +224,7 @@ func resourceIBMPIInstanceSnapshotUpdate(ctx context.Context, d *schema.Resource
 	if d.HasChange(Arg_SnapshotName) || d.HasChange(Arg_Description) {
 		name := d.Get(Arg_SnapshotName).(string)
 		description := d.Get(Arg_Description).(string)
-		snapshotBody := &models.SnapshotUpdate{Name: name, Description: description}
+		snapshotBody := &models.SnapshotUpdate{Name: &name, Description: &description}
 
 		_, err := client.Update(snapshotID, snapshotBody)
 		if err != nil {

--- a/ibm/service/power/resource_ibm_pi_network.go
+++ b/ibm/service/power/resource_ibm_pi_network.go
@@ -752,7 +752,7 @@ func networkMapToNetworkCreatePeer(networkCreatePeerMap map[string]interface{}) 
 	ncp := &models.NetworkCreatePeer{}
 	if networkCreatePeerMap[Attr_ID].(string) != "" {
 		id := networkCreatePeerMap[Attr_ID].(string)
-		ncp.ID = &id
+		ncp.ID = id
 	}
 	if networkCreatePeerMap[Attr_NetworkAddressTranslation] != nil && len(networkCreatePeerMap[Attr_NetworkAddressTranslation].([]interface{})) > 0 {
 		networkAddressTranslationModel := natMapToNetworkAddressTranslation(networkCreatePeerMap[Attr_NetworkAddressTranslation].([]interface{})[0].(map[string]interface{}))

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -343,7 +343,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 			d.Set(Arg_SharedProcessorPoolPlacementGroups, pgIDs)
 		}
 	}
-	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate)
+	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate.String())
 	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Status, response.SharedProcessorPool.Status)

--- a/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
+++ b/ibm/service/power/resource_ibm_pi_shared_processor_pool.go
@@ -103,6 +103,11 @@ func ResourceIBMPISharedProcessorPool() *schema.Resource {
 				Description: "The available cores in the shared processor pool.",
 				Type:        schema.TypeInt,
 			},
+			Attr_CreationDate: {
+				Computed:    true,
+				Description: "Date of shared processor pool creation.",
+				Type:        schema.TypeString,
+			},
 			Attr_CRN: {
 				Computed:    true,
 				Description: "The CRN of this resource.",
@@ -338,6 +343,7 @@ func resourceIBMPISharedProcessorPoolRead(ctx context.Context, d *schema.Resourc
 			d.Set(Arg_SharedProcessorPoolPlacementGroups, pgIDs)
 		}
 	}
+	d.Set(Attr_CreationDate, response.SharedProcessorPool.CreationDate)
 	d.Set(Attr_DedicatedHostID, response.SharedProcessorPool.DedicatedHostID)
 	d.Set(Attr_HostID, response.SharedProcessorPool.HostID)
 	d.Set(Attr_Status, response.SharedProcessorPool.Status)

--- a/ibm/service/power/resource_ibm_pi_snapshot.go
+++ b/ibm/service/power/resource_ibm_pi_snapshot.go
@@ -228,7 +228,7 @@ func resourceIBMPISnapshotUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange(Arg_SnapShotName) || d.HasChange(Arg_Description) {
 		name := d.Get(Arg_SnapShotName).(string)
 		description := d.Get(Arg_Description).(string)
-		snapshotBody := &models.SnapshotUpdate{Name: name, Description: description}
+		snapshotBody := &models.SnapshotUpdate{Name: &name, Description: &description}
 
 		_, err := client.Update(snapshotID, snapshotBody)
 		if err != nil {

--- a/website/docs/d/pi_shared_processor_pool.html.markdown
+++ b/website/docs/d/pi_shared_processor_pool.html.markdown
@@ -48,6 +48,7 @@ In addition to all argument reference list, you can access the following attribu
 
 - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
 - `available_cores` - (Integer) The available cores in the shared processor pool.
+- `creation_date` - (String) Date of shared processor pool creation.
 - `crn` - (String) The CRN of this resource.
 - `dedicated_host_id` - (String) The dedicated host ID where the shared processor pool resides.
 - `host_id` - (Integer) The host ID where the shared processor pool resides.

--- a/website/docs/d/pi_shared_processor_pools.html.markdown
+++ b/website/docs/d/pi_shared_processor_pools.html.markdown
@@ -49,6 +49,7 @@ In addition to all argument reference list, you can access the following attribu
   Nested scheme for `shared_processor_pools`:
   - `allocated_cores` - (Float) The allocated cores in the shared processor pool.
   - `available_cores` - (Integer) The available cores in the shared processor pool.
+  - `creation_date` - (String) Date of shared processor pool creation.
   - `crn` - (String) The CRN of this resource.
   - `dedicated_host_id` - (String) The dedicated host ID where the shared processor pool resides.
   - `host_id` - (Integer) The host ID where the shared processor pool resides.


### PR DESCRIPTION
This PR adds the Creation Date attribute to spp data source and resource.

Output from acceptance testing
```
--- PASS: TestAccIBMPIPISharedProcessorPoolDataSource_basic (31.64s)
PASS

--- PASS: TestAccIBMPISharedProcessorPoolsDataSourceBasic (40.76s)
PASS

--- PASS: TestAccIBMPISPPbasic (52.25s)
PASS

--- PASS: TestAccIBMPISPPUserTags (93.22s)
PASS
```