### PR TITLE
Refactor terraform errors to use new toolchain in instance, instance snapshot, instance ip, instance volume data sources

### DIFF
--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -281,10 +282,12 @@ func DataSourceIBMPIInstance() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -292,7 +295,9 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	powerC := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
 	powervmdata, err := powerC.Get(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_instance", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	pvminstanceid := *powervmdata.PvmInstanceID

--- a/ibm/service/power/data_source_ibm_pi_instance_ip.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_ip.go
@@ -5,11 +5,14 @@ package power
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net"
 	"strconv"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
 	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/conns"
+	"github.com/IBM-Cloud/terraform-provider-ibm/ibm/flex"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -97,10 +100,12 @@ func DataSourceIBMPIInstanceIP() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance_ip", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -109,7 +114,9 @@ func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData,
 
 	powervmdata, err := powerC.Get(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_instance_ip", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	for _, network := range powervmdata.Networks {
@@ -137,5 +144,8 @@ func dataSourceIBMPIInstancesIPRead(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	return diag.Errorf("failed to find instance ip that belongs to the given network")
+	err = flex.FmtErrorf("failed to find instance ip that belongs to the given network")
+	tfErr := flex.TerraformErrorf(err, fmt.Sprintf("operation failed: %s", err.Error()), "(Data) ibm_pi_instance_ip", "read")
+	log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+	return tfErr.GetDiag()
 }

--- a/ibm/service/power/data_source_ibm_pi_instance_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_snapshot.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -95,17 +96,21 @@ func DataSourceIBMPIInstanceSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstanceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstanceSnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotData, err := snapshot.Get(d.Get(Arg_SnapshotID).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_instance_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	d.SetId(*snapshotData.SnapshotID)

--- a/ibm/service/power/data_source_ibm_pi_instance_snapshots.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_snapshots.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -105,17 +106,21 @@ func DataSourceIBMPIInstanceSnapshots() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstanceSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstanceSnapshotsRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance_snapshots", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
 	snapshot := instance.NewIBMPISnapshotClient(ctx, sess, cloudInstanceID)
 	snapshotData, err := snapshot.GetAll()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetAll failed: %s", err.Error()), "(Data) ibm_pi_instance_snapshots", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()
@@ -125,11 +130,11 @@ func dataSourceIBMPIInstanceSnapshotsRead(ctx context.Context, d *schema.Resourc
 	return nil
 }
 
-func flattenSnapshotsInstances(list []*models.Snapshot, meta interface{}) []map[string]interface{} {
+func flattenSnapshotsInstances(list []*models.Snapshot, meta any) []map[string]any {
 	log.Printf("Calling the flattenSnapshotsInstances call with list %d", len(list))
-	result := make([]map[string]interface{}, 0, len(list))
+	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
-		l := map[string]interface{}{
+		l := map[string]any{
 			Attr_Action:          i.Action,
 			Attr_CreationDate:    i.CreationDate.String(),
 			Attr_Description:     i.Description,

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -137,10 +138,12 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "(Data) ibm_pi_instance_volumes", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
@@ -148,7 +151,9 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
 	volumedata, err := volumeC.GetAllInstanceVolumes(d.Get(Arg_InstanceName).(string))
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf(" failed: %s", err.Error()), "(Data) ibm_pi_instance_volumes", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()
@@ -162,10 +167,10 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 	return nil
 }
 
-func flattenVolumesInstances(list []*models.VolumeReference, meta interface{}) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(list))
+func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[string]any {
+	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
-		l := map[string]interface{}{
+		l := map[string]any{
 			Attr_Bootable:           *i.Bootable,
 			Attr_CreationDate:       i.CreationDate.String(),
 			Attr_Href:               *i.Href,


### PR DESCRIPTION
Output from acceptance testing:
```
--- PASS: TestAccIBMPIInstancesDataSource_basic (59.29s)
PASS

--- PASS: TestAccIBMPIInstanceDataSource_basic (18.06s)
PASS

--- PASS: TestAccIBMPIVolumesDataSource_basic (18.89s)
PASS

--- PASS: TestAccIBMPIInstanceSnapshotsDataSource_basic (31.91s)
PASS

--- PASS: TestAccIBMPIInstanceSnapshotDataSource_basic (14.31s)
PASS

--- PASS: TestAccIBMPIInstanceIPDataSource_basic (34.52s)
PASS
```