### PR TITLE
Fix instance data sources to use id 

### DIFF
--- a/ibm/acctest/acctest.go
+++ b/ibm/acctest/acctest.go
@@ -237,6 +237,7 @@ var (
 	Pi_image_bucket_region            string
 	Pi_image_bucket_secret_key        string
 	Pi_image_id                       string
+	Pi_instance_id                    string
 	Pi_instance_name                  string
 	Pi_key_name                       string
 	Pi_network_address_group_id       string
@@ -1315,10 +1316,16 @@ func init() {
 		fmt.Println("[INFO] Set the environment variable PI_SNAPSHOT_ID for testing ibm_pi_instance_snapshot data source else it is set to default value '1ea33118-4c43-4356-bfce-904d0658de82'")
 	}
 
-	Pi_instance_name = os.Getenv("PI_PVM_INSTANCE_NAME")
+	Pi_instance_id = os.Getenv("PI_INSTANCE_ID")
+	if Pi_instance_id == "" {
+		Pi_instance_id = "terraform-test-power"
+		fmt.Println("[INFO] Set the environment variable PI_INSTANCE_ID for testing PI_INSTANCE_ID resource else it is set to default value 'terraform-test-power'")
+	}
+
+	Pi_instance_name = os.Getenv("PI_INSTANCE_NAME")
 	if Pi_instance_name == "" {
 		Pi_instance_name = "terraform-test-power"
-		fmt.Println("[INFO] Set the environment variable PI_PVM_INSTANCE_ID for testing Pi_instance_name resource else it is set to default value 'terraform-test-power'")
+		fmt.Println("[INFO] Set the environment variable PI_INSTANCE_NAME for testing PI_INSTANCE_NAME resource else it is set to default value 'terraform-test-power'")
 	}
 
 	Pi_dhcp_id = os.Getenv("PI_DHCP_ID")

--- a/ibm/service/power/data_source_ibm_pi_instance.go
+++ b/ibm/service/power/data_source_ibm_pi_instance.go
@@ -27,11 +27,21 @@ func DataSourceIBMPIInstance() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.NoZeroValues,
 			},
+			Arg_InstanceID: {
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceName},
+				Description:   "The ID of the PVM instance.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
+			},
 			Arg_InstanceName: {
-				Description:  "The unique identifier or name of the instance.",
-				Required:     true,
-				Type:         schema.TypeString,
-				ValidateFunc: validation.NoZeroValues,
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceID},
+				Description:   "The name of the PVM instance.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
 			},
 
 			// Attributes
@@ -301,9 +311,15 @@ func dataSourceIBMPIInstancesRead(ctx context.Context, d *schema.ResourceData, m
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	var instanceID string
+	if v, ok := d.GetOk(Arg_InstanceID); ok {
+		instanceID = v.(string)
+	} else if v, ok := d.GetOk(Arg_InstanceName); ok {
+		instanceID = v.(string)
+	}
 
 	powerC := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
-	powervmdata, err := powerC.Get(d.Get(Arg_InstanceName).(string))
+	powervmdata, err := powerC.Get(instanceID)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("Get failed: %s", err.Error()), "(Data) ibm_pi_instance", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())

--- a/ibm/service/power/data_source_ibm_pi_instance_console_languages_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_console_languages_test.go
@@ -31,7 +31,7 @@ func TestAccIBMPIInstanceConsoleLanguages(t *testing.T) {
 func testAccCheckIBMPIInstanceConsoleLanguagesConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_console_languages" "example" {
-			pi_cloud_instance_id = "%s"
-			pi_instance_name     = "%s"
-		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_name)
+			pi_cloud_instance_id = "%[1]s"
+			pi_instance_id       = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_id)
 }

--- a/ibm/service/power/data_source_ibm_pi_instance_ip_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_ip_test.go
@@ -30,8 +30,8 @@ func TestAccIBMPIInstanceIPDataSource_basic(t *testing.T) {
 func testAccCheckIBMPIInstanceIPDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_instance_ip" "testacc_ds_instance_ip" {
-			pi_network_name = "%[1]s"
-			pi_instance_name = "%[2]s"
-			pi_cloud_instance_id = "%[3]s"
-		}`, acc.Pi_network_name, acc.Pi_instance_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_instance_id       = "%[2]s"
+			pi_network_id        = "%[3]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_id, acc.Pi_network_id)
 }

--- a/ibm/service/power/data_source_ibm_pi_instance_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_test.go
@@ -31,7 +31,7 @@ func TestAccIBMPIInstanceDataSource_basic(t *testing.T) {
 func testAccCheckIBMPIInstanceDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_instance" "testacc_ds_instance" {
-			pi_instance_name="%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_instance_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_instance_id       = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_id)
 }

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes.go
@@ -29,11 +29,21 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.NoZeroValues,
 			},
+			Arg_InstanceID: {
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceName},
+				Description:   "The PVM instance ID.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
+			},
 			Arg_InstanceName: {
-				Description:  "The unique identifier or name of the instance.",
-				Required:     true,
-				Type:         schema.TypeString,
-				ValidateFunc: validation.NoZeroValues,
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceID},
+				Description:   "The name of the PVM instance.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
 			},
 
 			// Attribute
@@ -47,10 +57,25 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 				Description: "List of volumes attached to instance.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						Attr_Auxiliary: {
+							Computed:    true,
+							Description: "Indicates if the volume is auxiliary or not.",
+							Type:        schema.TypeBool,
+						},
+						Attr_AuxiliaryVolumeName: {
+							Computed:    true,
+							Description: "The auxiliary volume name.",
+							Type:        schema.TypeString,
+						},
 						Attr_Bootable: {
 							Computed:    true,
 							Description: "Indicates if the volume is boot capable.",
 							Type:        schema.TypeBool,
+						},
+						Attr_ConsistencyGroupName: {
+							Computed:    true,
+							Description: "The name of consistency group at storage controller level.",
+							Type:        schema.TypeString,
 						},
 						Attr_CreationDate: {
 							Computed:    true,
@@ -62,9 +87,19 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "The CRN of this resource.",
 							Type:        schema.TypeString,
 						},
+						Attr_DeleteOnTermination: {
+							Computed:    true,
+							Description: "Indicates if the volume should be deleted when the server terminates.",
+							Type:        schema.TypeBool,
+						},
 						Attr_FreezeTime: {
 							Computed:    true,
 							Description: "The freeze time of remote copy.",
+							Type:        schema.TypeString,
+						},
+						Attr_GroupID: {
+							Computed:    true,
+							Description: "The volume group id in which the volume belongs.",
 							Type:        schema.TypeString,
 						},
 						Attr_Href: {
@@ -77,9 +112,24 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "The unique identifier of the volume.",
 							Type:        schema.TypeString,
 						},
+						Attr_IOThrottleRate: {
+							Computed:    true,
+							Description: "Amount of iops assigned to the volume",
+							Type:        schema.TypeString,
+						},
 						Attr_LastUpdateDate: {
 							Computed:    true,
 							Description: "The last updated date of the volume.",
+							Type:        schema.TypeString,
+						},
+						Attr_MasterVolumeName: {
+							Computed:    true,
+							Description: "Indicates master volume name",
+							Type:        schema.TypeString,
+						},
+						Attr_MirroringState: {
+							Computed:    true,
+							Description: "Mirroring state for replication enabled volume",
 							Type:        schema.TypeString,
 						},
 						Attr_Name: {
@@ -87,9 +137,19 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "The name of the volume.",
 							Type:        schema.TypeString,
 						},
+						Attr_OutOfBandDeleted: {
+							Computed:    true,
+							Description: "Indicates if the volume does not exist on storage controller.",
+							Type:        schema.TypeBool,
+						},
 						Attr_Pool: {
 							Computed:    true,
 							Description: "Volume pool, name of storage pool where the volume is located.",
+							Type:        schema.TypeString,
+						},
+						Attr_PrimaryRole: {
+							Computed:    true,
+							Description: "Indicates whether master/aux volume is playing the primary role.",
 							Type:        schema.TypeString,
 						},
 						Attr_ReplicationEnabled: {
@@ -102,6 +162,16 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Description: "List of replication sites for volume replication.",
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Type:        schema.TypeList,
+						},
+						Attr_ReplicationStatus: {
+							Computed:    true,
+							Description: "The replication status of the volume.",
+							Type:        schema.TypeString,
+						},
+						Attr_ReplicationType: {
+							Computed:    true,
+							Description: "The replication type of the volume, 'metro' or 'global'.",
+							Type:        schema.TypeString,
 						},
 						Attr_Shareable: {
 							Computed:    true,
@@ -130,6 +200,21 @@ func DataSourceIBMPIInstanceVolumes() *schema.Resource {
 							Set:         schema.HashString,
 							Type:        schema.TypeSet,
 						},
+						Attr_VolumePool: {
+							Computed:    true,
+							Description: "Name of the storage pool where the volume is located.",
+							Type:        schema.TypeString,
+						},
+						Attr_VolumeType: {
+							Computed:    true,
+							Description: "Name of storage template used to create the volume.",
+							Type:        schema.TypeString,
+						},
+						Attr_WWN: {
+							Computed:    true,
+							Description: "The world wide name of the volume.",
+							Type:        schema.TypeString,
+						},
 					},
 				},
 				Type: schema.TypeList,
@@ -147,9 +232,15 @@ func dataSourceIBMPIInstanceVolumesRead(ctx context.Context, d *schema.ResourceD
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
+	var instanceID string
+	if v, ok := d.GetOk(Arg_InstanceID); ok {
+		instanceID = v.(string)
+	} else if v, ok := d.GetOk(Arg_InstanceName); ok {
+		instanceID = v.(string)
+	}
 
 	volumeC := instance.NewIBMPIVolumeClient(ctx, sess, cloudInstanceID)
-	volumedata, err := volumeC.GetAllInstanceVolumes(d.Get(Arg_InstanceName).(string))
+	volumedata, err := volumeC.GetAllInstanceVolumes(instanceID)
 	if err != nil {
 		tfErr := flex.TerraformErrorf(err, fmt.Sprintf(" failed: %s", err.Error()), "(Data) ibm_pi_instance_volumes", "read")
 		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
@@ -171,18 +262,32 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[str
 	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
 		l := map[string]any{
-			Attr_Bootable:           *i.Bootable,
-			Attr_CreationDate:       i.CreationDate.String(),
-			Attr_Href:               *i.Href,
-			Attr_ID:                 *i.VolumeID,
-			Attr_LastUpdateDate:     i.LastUpdateDate.String(),
-			Attr_Name:               *i.Name,
-			Attr_Pool:               i.VolumePool,
-			Attr_ReplicationEnabled: i.ReplicationEnabled,
-			Attr_Shareable:          *i.Shareable,
-			Attr_Size:               *i.Size,
-			Attr_State:              *i.State,
-			Attr_Type:               *i.DiskType,
+			Attr_Auxiliary:            *i.Auxiliary,
+			Attr_AuxiliaryVolumeName:  i.AuxVolumeName,
+			Attr_Bootable:             *i.Bootable,
+			Attr_ConsistencyGroupName: i.ConsistencyGroupName,
+			Attr_CreationDate:         i.CreationDate.String(),
+			Attr_GroupID:              i.GroupID,
+			Attr_Href:                 *i.Href,
+			Attr_ID:                   *i.VolumeID,
+			Attr_IOThrottleRate:       i.IoThrottleRate,
+			Attr_LastUpdateDate:       i.LastUpdateDate.String(),
+			Attr_MasterVolumeName:     i.MasterVolumeName,
+			Attr_MirroringState:       i.MirroringState,
+			Attr_Name:                 *i.Name,
+			Attr_OutOfBandDeleted:     i.OutOfBandDeleted,
+			Attr_Pool:                 i.VolumePool,
+			Attr_PrimaryRole:          i.PrimaryRole,
+			Attr_ReplicationEnabled:   i.ReplicationEnabled,
+			Attr_ReplicationStatus:    i.ReplicationStatus,
+			Attr_ReplicationType:      i.ReplicationType,
+			Attr_Shareable:            *i.Shareable,
+			Attr_Size:                 *i.Size,
+			Attr_State:                *i.State,
+			Attr_Type:                 *i.DiskType,
+			Attr_VolumePool:           i.VolumePool,
+			Attr_VolumeType:           i.VolumeType,
+			Attr_WWN:                  *i.Wwn,
 		}
 		if i.Crn != "" {
 			l[Attr_CRN] = i.Crn
@@ -191,6 +296,9 @@ func flattenVolumesInstances(list []*models.VolumeReference, meta any) []map[str
 				log.Printf("Error on get of volume (%s) user_tags: %s", *i.VolumeID, err)
 			}
 			l[Attr_UserTags] = tags
+		}
+		if i.DeleteOnTermination != nil {
+			l[Attr_DeleteOnTermination] = *i.DeleteOnTermination
 		}
 		if i.FreezeTime != nil {
 			l[Attr_FreezeTime] = i.FreezeTime.String()

--- a/ibm/service/power/data_source_ibm_pi_instance_volumes_test.go
+++ b/ibm/service/power/data_source_ibm_pi_instance_volumes_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccIBMPIVolumesDataSource_basic(t *testing.T) {
+func TestAccIBMPIInstanceVolumesDataSource_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { acc.TestAccPreCheck(t) },
 		Providers: acc.TestAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckIBMPIVolumesDataSourceConfig(),
+				Config: testAccCheckIBMPIInstanceVolumesDataSourceConfig(),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ibm_pi_instance_volumes.testacc_ds_volumes", "id"),
 				),
@@ -27,10 +27,10 @@ func TestAccIBMPIVolumesDataSource_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckIBMPIVolumesDataSourceConfig() string {
+func testAccCheckIBMPIInstanceVolumesDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_instance_volumes" "testacc_ds_volumes" {
-			pi_instance_name = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_instance_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_instance_id       = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_id)
 }

--- a/ibm/service/power/data_source_ibm_pi_pvm_snapshot.go
+++ b/ibm/service/power/data_source_ibm_pi_pvm_snapshot.go
@@ -5,6 +5,7 @@ package power
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/IBM-Cloud/power-go-client/clients/instance"
@@ -28,11 +29,21 @@ func DataSourceIBMPIPVMSnapshot() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.NoZeroValues,
 			},
+			Arg_InstanceID: {
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceName},
+				Description:   "The ID of the PVM instance.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
+			},
 			Arg_InstanceName: {
-				Description:  "The unique identifier or name of the instance.",
-				Required:     true,
-				Type:         schema.TypeString,
-				ValidateFunc: validation.NoZeroValues,
+				AtLeastOneOf:  []string{Arg_InstanceID, Arg_InstanceName},
+				ConflictsWith: []string{Arg_InstanceID},
+				Description:   "The name of the PVM instance.",
+				Optional:      true,
+				Type:          schema.TypeString,
+				ValidateFunc:  validation.NoZeroValues,
 			},
 
 			// Attributes
@@ -105,19 +116,29 @@ func DataSourceIBMPIPVMSnapshot() *schema.Resource {
 	}
 }
 
-func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	sess, err := meta.(conns.ClientSession).IBMPISession()
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("IBMPISession failed: %s", err.Error()), "ibm_pi_pvm_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	cloudInstanceID := d.Get(Arg_CloudInstanceID).(string)
-	powerinstancename := d.Get(Arg_InstanceName).(string)
+	var instanceID string
+	if v, ok := d.GetOk(Arg_InstanceID); ok {
+		instanceID = v.(string)
+	} else if v, ok := d.GetOk(Arg_InstanceName); ok {
+		instanceID = v.(string)
+	}
+
 	snapshot := instance.NewIBMPIInstanceClient(ctx, sess, cloudInstanceID)
-	snapshotData, err := snapshot.GetSnapShotVM(powerinstancename)
+	snapshotData, err := snapshot.GetSnapShotVM(instanceID)
 
 	if err != nil {
-		return diag.FromErr(err)
+		tfErr := flex.TerraformErrorf(err, fmt.Sprintf("GetSnapShotVM failed: %s", err.Error()), "ibm_pi_pvm_snapshot", "read")
+		log.Printf("[DEBUG]\n%s", tfErr.GetDebugMessage())
+		return tfErr.GetDiag()
 	}
 
 	var clientgenU, _ = uuid.GenerateUUID()
@@ -127,11 +148,11 @@ func dataSourceIBMPISnapshotRead(ctx context.Context, d *schema.ResourceData, me
 	return nil
 }
 
-func flattenPVMSnapshotInstances(list []*models.Snapshot, meta interface{}) []map[string]interface{} {
+func flattenPVMSnapshotInstances(list []*models.Snapshot, meta any) []map[string]any {
 	log.Printf("Calling the flattenPVMSnapshotInstances call with list %d", len(list))
-	result := make([]map[string]interface{}, 0, len(list))
+	result := make([]map[string]any, 0, len(list))
 	for _, i := range list {
-		l := map[string]interface{}{
+		l := map[string]any{
 			Attr_Action:          i.Action,
 			Attr_CreationDate:    i.CreationDate.String(),
 			Attr_Description:     i.Description,

--- a/ibm/service/power/data_source_ibm_pi_pvm_snapshot_test.go
+++ b/ibm/service/power/data_source_ibm_pi_pvm_snapshot_test.go
@@ -31,7 +31,7 @@ func TestAccIBMPISnapshotDataSource_basic(t *testing.T) {
 func testAccCheckIBMPISnapshotDataSourceConfig() string {
 	return fmt.Sprintf(`
 		data "ibm_pi_pvm_snapshots" "testacc_pi_snapshots" {
-			pi_instance_name = "%s"
-			pi_cloud_instance_id = "%s"
-		}`, acc.Pi_instance_name, acc.Pi_cloud_instance_id)
+			pi_cloud_instance_id = "%[1]s"
+			pi_instance_id       = "%[2]s"
+		}`, acc.Pi_cloud_instance_id, acc.Pi_instance_id)
 }

--- a/ibm/service/power/ibm_pi_constants.go
+++ b/ibm/service/power/ibm_pi_constants.go
@@ -555,6 +555,7 @@ const (
 	Attr_VolumeSnapshots                     = "volume_snapshots"
 	Attr_VolumesSnapshots                    = "volume_snapshots"
 	Attr_VolumeStatus                        = "volume_status"
+	Attr_VolumeType                          = "volume_type"
 	Attr_VPCCRNs                             = "vpc_crns"
 	Attr_VPCEnabled                          = "vpc_enabled"
 	Attr_WorkloadType                        = "workload_type"

--- a/website/docs/d/pi_console_languages.html.markdown
+++ b/website/docs/d/pi_console_languages.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Retrieve information about all the available Console Languages for an Instance. For more information, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
 
 ```terraform
 data "ibm_pi_console_languages" "example" {
@@ -40,7 +40,8 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
+- `pi_instance_id` - (Optional, String) The PVM instance ID.
+- `pi_instance_name` - (Deprecated, Optional, String) The unique identifier or name of the instance. Passing the name of the instance could fail or fetch stale data. Please pass an id and use `pi_instance_id` instead.
 
 ## Attribute Reference
 

--- a/website/docs/d/pi_instance.html.markdown
+++ b/website/docs/d/pi_instance.html.markdown
@@ -40,7 +40,8 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
+- `pi_instance_id` - (Optional, String) The PVM instance ID.
+- `pi_instance_name` - (Deprecated, Optional, String) The unique identifier or name of the instance. Passing the name of the instance could fail or fetch stale data. Please pass an id and use `pi_instance_id` instead.
 
 ## Attribute Reference
 

--- a/website/docs/d/pi_instance_volumes.html.markdown
+++ b/website/docs/d/pi_instance_volumes.html.markdown
@@ -42,7 +42,8 @@ Example usage:
 Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
+- `pi_instance_id` - (Optional, String) The PVM instance ID.
+- `pi_instance_name` - (Deprecated, Optional, String) The unique identifier or name of the instance. Passing the name of the instance could fail or fetch stale data. Please pass an id and use `pi_instance_id` instead.
 
 ## Attribute Reference
 
@@ -52,19 +53,34 @@ In addition to all argument reference list, you can access the following attribu
 - `instance_volumes` - (List) List of volumes attached to instance.
 
   Nested scheme for `instance_volumes`:
+  - `auxiliary_volume_name` - (String) The auxiliary volume name.
+  - `auxiliary` - (Boolean) Indicates if the volume is auxiliary or not.
   - `bootable`- (Boolean) Indicates if the volume is boot capable.
+  - `consistency_group_name` - (String) The consistency group name if volume is a part of volume group.
   - `creation_date` - (String) Date of volume creation.
   - `crn` - (String) The CRN of this resource.
+  - `delete_on_termination` - (Boolean) Indicates if the volume should be deleted when the server terminates.
   - `freeze_time` - (String) Time of remote copy relationship.
+  - `group_id` - (String) The volume group id to which volume belongs.
   - `href` - (String) The hyper link of the volume.
   - `id` - (String) The unique identifier of the volume.
+  - `io_throttle_rate` - (String) Amount of iops assigned to the volume.
   - `last_update_date` - (String) The date when the volume last updated.
+  - `master_volume_name` - (String) The master volume name.
+  - `mirroring_state` - (String) Mirroring state for replication enabled volume.
   - `name` - (String) The name of the volume.
+  - `out_of_band_deleted` - (Bool) Indicates if the volume does not exist on storage controller.
   - `pool` - (String) Volume pool, name of storage pool where the volume is located.
+  - `primary_role` - (String) Indicates whether `master`/`auxiliary` volume is playing the primary role.
   - `replication_enabled` - (Boolean) Indicates whether replication is enabled on the volume.
   - `replication_sites` - (List) List of replication sites for volume replication.
+  - `replication_status` - (String) The replication status of the volume.
+  - `replication_type` - (String) The replication type of the volume, `metro` or `global`.
   - `shareable` - (Boolean) Indicates if the volume is shareable between VMs.
   - `size` - (Integer) The size of this volume in GB.
   - `state` - (String) The state of the volume.
   - `type` - (String) The disk type that is used for this volume.
   - `user_tags` - (List) List of user tags attached to the resource.
+  - `volume_pool` - (String) Name of the storage pool where the volume is located.
+  - `volume_type` - (String) Name of storage template used to create the volume.
+  - `wwn` - (String) The world wide name of the volume.

--- a/website/docs/d/pi_pvm_snapshots.html.markdown
+++ b/website/docs/d/pi_pvm_snapshots.html.markdown
@@ -7,9 +7,11 @@ description: |-
 ---
 
 # ibm_pi_pvm_snapshots
+
 Retrieve information about a Power Systems Virtual Server instance snapshots. For more information, about Power Virtual Server PVM instance snapshots, see [getting started with IBM Power Systems Virtual Servers](https://cloud.ibm.com/docs/power-iaas?topic=power-iaas-getting-started).
 
-## Example usage
+## Example Usage
+
 ```terraform
 data "ibm_pi_pvm_snapshots" "ds_pvm_snapshots" {
   pi_instance_name     = "terraform-test-instance"
@@ -17,13 +19,15 @@ data "ibm_pi_pvm_snapshots" "ds_pvm_snapshots" {
 }
 ```
 
-**Notes**
+### Notes
+
 - Please find [supported Regions](https://cloud.ibm.com/apidocs/power-cloud#endpoint) for endpoints.
 - If a Power cloud instance is provisioned at `lon04`, The provider level attributes should be as follows:
   - `region` - `lon`
   - `zone` - `lon04`
 
 Example usage:
+
   ```terraform
     provider "ibm" {
       region    =   "lon"
@@ -31,14 +35,17 @@ Example usage:
     }
   ```
 
-## Argument reference
-Review the argument references that you can specify for your data source. 
+## Argument Reference
+
+Review the argument references that you can specify for your data source.
 
 - `pi_cloud_instance_id` - (Required, String) The GUID of the service instance associated with an account.
-- `pi_instance_name` - (Required, String) The unique identifier or name of the instance.
+- `pi_instance_id` - (Optional, String) The PVM instance ID.
+- `pi_instance_name` - (Deprecated, Optional, String) The unique identifier or name of the instance. Passing the name of the instance could fail or fetch stale data. Please pass an id and use `pi_instance_id` instead.
 
-## Attribute reference
-In addition to all argument reference list, you can access the following attribute references after your data source is created. 
+## Attribute Reference
+
+In addition to all argument reference list, you can access the following attribute references after your data source is created.
 
 - `pvm_snapshots` - The list of Power Virtual Machine instance snapshots.
   


### PR DESCRIPTION
Deprecate the use of pi_instance_name on the ibm_pi_instance, ibm_pi_instance_console_languages, ibm_pi_instance_volumes, and ibm_pi_pvm_snapshot data sources for pi_instance_id.

Output from acceptance testing:

```
--- PASS: TestAccIBMPIInstanceDataSource_basic (44.64s)
PASS

--- PASS: TestAccIBMPIInstanceConsoleLanguages (18.56s)
PASS

--- PASS: TestAccIBMPInstanceVolumesDataSource_basic (23.19s)
PASS

--- PASS: TestAccIBMPISnapshotDataSource_basic (18.25s)
PASS
```

